### PR TITLE
Ported Java Open MPI notebook and dynamic load balancing example

### DIFF
--- a/Patternlets/java-OpenMPI/24.dynamicLoadBalance/DynamicLoadBalance.java
+++ b/Patternlets/java-OpenMPI/24.dynamicLoadBalance/DynamicLoadBalance.java
@@ -44,9 +44,9 @@ public class DynamicLoadBalance {
             worker(MPI.COMM_WORLD);
        }   
        MPI.Finalize();
-     }
+    }
 
-     private static int[] genTasks(int numTasks) {
+    private static int[] genTasks(int numTasks) {
         int[] tasks = new int[numTasks];
         Random r = new Random(1000); // use the same seed
         for(int i = 0; i < numTasks; i++) {

--- a/Patternlets/java-OpenMPI/24.dynamicLoadBalance/DynamicLoadBalance.java
+++ b/Patternlets/java-OpenMPI/24.dynamicLoadBalance/DynamicLoadBalance.java
@@ -13,22 +13,12 @@
  * - Explain behavior of the dynamic load balancing of the available work
  */
 
+import mpi.*;
+import java.nio.IntBuffer;
 import java.util.Arrays;
 import java.util.Random;
 
-import mpi.*;
-import java.nio.IntBuffer;
-
 public class DynamicLoadBalance {
-    private static int[] genTasks(int numTasks) {
-        int[] tasks = new int[numTasks];
-        Random r = new Random(1000); // use the same seed
-        for(int i = 0; i < numTasks; i++) {
-            tasks[i] = r.nextInt(8) + 1;
-        }
-        return tasks;
-    }
-
     public static final int MASTER = 0;
 
     // tags that can be applied to messages
@@ -55,6 +45,15 @@ public class DynamicLoadBalance {
        }   
        MPI.Finalize();
      }
+
+     private static int[] genTasks(int numTasks) {
+        int[] tasks = new int[numTasks];
+        Random r = new Random(1000); // use the same seed
+        for(int i = 0; i < numTasks; i++) {
+            tasks[i] = r.nextInt(8) + 1;
+        }
+        return tasks;
+    }
 
     private static void worker(Comm comm) throws MPIException {
         // keep receiving messages and do work, unless tagged to 'die'

--- a/Patternlets/java-OpenMPI/24.dynamicLoadBalance/DynamicLoadBalance.java
+++ b/Patternlets/java-OpenMPI/24.dynamicLoadBalance/DynamicLoadBalance.java
@@ -1,0 +1,130 @@
+/* DynamicLoadBalance.java
+ * ... illustrates how to use the dynamic load balancing pattern 
+ *     using OpenMPI's Java interface.
+ * This code was based on the dynamicLoadBalance.py script,
+ * that was originally written by Libby Shoop (Macalester College)
+ * 
+ * Ruth Kurniawati, Westfield State University, June 2021.
+ *
+ * Usage: mpirun -np 4 java ./DynamicLoadBalance
+ *
+ * Exercise:
+ * - Compile and run, varying N = 4, 8.
+ * - Explain behavior of the dynamic load balancing of the available work
+ */
+
+import java.util.Arrays;
+import java.util.Random;
+
+import mpi.*;
+import java.nio.IntBuffer;
+
+public class DynamicLoadBalance {
+    private static int[] genTasks(int numTasks) {
+        int[] tasks = new int[numTasks];
+        Random r = new Random(1000); // use the same seed
+        for(int i = 0; i < numTasks; i++) {
+            tasks[i] = r.nextInt(8) + 1;
+        }
+        return tasks;
+    }
+
+    public static final int MASTER = 0;
+
+    // tags that can be applied to messages
+    public static final int WORKTAG = 1;
+    public static final int DIETAG = 2;
+
+    public static void main(String [] args) throws MPIException {
+       MPI.Init(args);
+   
+       int id           = MPI.COMM_WORLD.getRank();
+       int numProcesses = MPI.COMM_WORLD.getSize();
+       //String hostName  = MPI.getProcessorName();
+   
+       if (id == MASTER) {
+            // create an arbitrary array of numbers for how long each
+            // worker task will 'work', by sleeping that amount of seconds
+            int numTasks = (numProcesses-1) * 4; // avg 4 tasks per worker process
+            int[] workTimes = genTasks(numTasks);
+            System.out.println("master created " + workTimes.length + " values for sleep times:" + Arrays.toString(workTimes));
+            handOutWork(MPI.COMM_WORLD, workTimes, numProcesses);
+            
+       } else {
+            worker(MPI.COMM_WORLD);
+       }   
+       MPI.Finalize();
+     }
+
+    private static void worker(Comm comm) throws MPIException {
+        // keep receiving messages and do work, unless tagged to 'die'
+        IntBuffer buf = MPI.newIntBuffer(1);
+        while(true) {
+            Status stat = comm.recv(buf, 1, MPI.INT, 0, MPI.ANY_TAG);
+            int waitTime = buf.get(0);
+            System.out.println("worker "+comm.getRank()+" got "+ waitTime);
+            if (stat.getTag() == DIETAG) {
+                System.out.println("worker "+comm.getRank()+" dying");
+                return;
+            }
+            // simulate work by sleeping
+            try {
+                Thread.sleep(1000*waitTime); // sleep for waitTime seconds
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            } 
+
+            // indicate done with work by sending to Master
+            //System.out.println("worker "+comm.getRank()+" completed work!");
+            buf.put(0, waitTime);
+            comm.send(buf, 1, MPI.INT, 0, WORKTAG);
+        }
+    }
+
+    private static void handOutWork(Comm comm, int[] workTimes, int numProcesses) throws MPIException {
+        int totalWork = workTimes.length;
+        int workCount = 0, recvCount = 0;
+        System.out.println("master sending first tasks");
+        IntBuffer sendBuf = MPI.newIntBuffer(1);
+         
+        for(int id = 1; id < numProcesses; id++) {
+            int work = workTimes[workCount++];
+            sendBuf.put(0, work);
+            comm.send(sendBuf, 1, MPI.INT, id, WORKTAG);
+            System.out.println("master sent "+ work +" to "+id);
+        }
+
+        // while there is still work,
+        // receive result from a worker, which also
+        // signals they would like some new work
+        IntBuffer recvBuf = MPI.newIntBuffer(1);
+        while (workCount < totalWork) {
+            // System.out.println("Master workcount " + workCount + ", total "+ totalWork);
+            // receive next finished result
+            Status stat = comm.recv(recvBuf, 1, MPI.INT, MPI.ANY_SOURCE, WORKTAG);
+            recvCount++;
+            int workerId = stat.getSource();
+            int completedWorkTime = recvBuf.get(0);
+            System.out.println("master received "+completedWorkTime+" from "+ workerId);
+            // send next work
+            int newWorkTime = workTimes[workCount++];
+            sendBuf.put(0, newWorkTime);
+            comm.send(sendBuf, 1, MPI.INT, workerId, WORKTAG);
+            System.out.println("master sent "+newWorkTime+" to "+ workerId);
+        }
+        // Receive results for outstanding work requests.
+        while (recvCount < totalWork) {
+            Status stat = comm.recv(recvBuf, 1, MPI.INT, MPI.ANY_SOURCE, WORKTAG);
+            recvCount++;
+            int workerId = stat.getSource();
+            int completedWorkTime = recvBuf.get(0);
+            System.out.println("end: master received "+completedWorkTime+" from "+ workerId);
+        }
+
+        // Tell all workers to stop
+        sendBuf.put(0, -1);
+        for(int id =1; id < numProcesses; id++) {
+            comm.send(sendBuf, 1, MPI.INT, id, DIETAG);
+        }
+    }       
+}

--- a/Patternlets/java-OpenMPI/24.dynamicLoadBalance/Makefile
+++ b/Patternlets/java-OpenMPI/24.dynamicLoadBalance/Makefile
@@ -1,0 +1,11 @@
+PROG  = DynamicLoadBalance
+CLASS = $(PROG).class
+SRC   = $(PROG).java
+CC    = mpijavac
+
+$(CLASS): $(SRC)
+	$(CC) $(SRC)
+
+clean:
+	rm -f $(CLASS) *~ *# 
+

--- a/Patternlets/java-OpenMPI/24.dynamicLoadBalance/run
+++ b/Patternlets/java-OpenMPI/24.dynamicLoadBalance/run
@@ -1,0 +1,15 @@
+#/bin/sh
+#
+# Joel C. Adams, Calvin University, November 2019.
+#
+# Change the following line to the name of your Java class
+
+PROG=DynamicLoadBalance
+
+if [ "$#" -gt 0 ]; then
+	mpirun --mca shmem posix --oversubscribe -np $1 java $PROG
+else
+	echo 'Please specify the number of processes (should be > 1), for example to run with 4 processes (3 workers):'
+	echo "$0 4"
+fi
+

--- a/Patternlets/java-OpenMPI/notebook/Java_openmpi_patternlets.ipynb
+++ b/Patternlets/java-OpenMPI/notebook/Java_openmpi_patternlets.ipynb
@@ -1,0 +1,2612 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "Java openmpi_patternlets.ipynb",
+      "provenance": [],
+      "collapsed_sections": [
+        "kVWqN3EhJFbJ",
+        "LJ_ThE3-KthZ",
+        "Vww7AO93S8QD",
+        "bXSiO5dGuJda",
+        "49L8NojO6axL",
+        "XxKI85d8LLll",
+        "UKgBEDizMkRM",
+        "lFx0VyZzN1Aw",
+        "eJQfgyqlOTCr",
+        "o6bvSqgMPeyt",
+        "57wzDFu2xxvW",
+        "n3eZ1sN1yVsK",
+        "tNe1kQLpyqh2",
+        "FcckAX8G0Pd-",
+        "ocfu_ZYw3QCz",
+        "0gcBP4q93eCj",
+        "IGWlHIPh4t08",
+        "cwiw83d44_gR",
+        "PrwM90WO6jKv",
+        "YRLLMm9j7iOA",
+        "JnO-S8V37tpD",
+        "P74yRNds9SBx",
+        "gL2CQgIo-xTd",
+        "1g5HzFU1--zY",
+        "H9EYqJldBRS-",
+        "tIw9YI6GB5go",
+        "mPVwi5W4DpwJ",
+        "-eCGJi2hEOC1",
+        "qKhQXI7oFRMf",
+        "t65YHXekHbBK"
+      ],
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "CXMYxZtKyP0I"
+      },
+      "source": [
+        "# Distributed Parallel Programming Patterns using Open MPI and Java\n",
+        "Java adaptation done by Ruth Kurniawati (Westfield State University) using source code from [CSInParallel](https://github.com/csinparallel/CSinParallel.git)\n",
+        "\n",
+        "Modified from mpi4py notebook originally written by Libby Shoop, Macalester College\n",
+        "\n",
+        "Welcome!\n",
+        "\n",
+        "This book contains some examples illustrating the basic fundamental concepts of distributed computing using Java code. The type of computing these examples illustrate is called *message passing*. Message passing is a form of programming that is based on processes that communicate with each other to coordinate their work. Message passing can be used on a single multicore computer or with a cluster of computers.\n",
+        "\n",
+        "### Software Patterns\n",
+        "\n",
+        "Patterns in software are common implementations that have been used over and over by practitioners to accomplish tasks. As practitioners use them repeatedly, the community begins to give them names and catalog them, often turning them into reusable library functions. The examples you will see in this book are based on documented patterns that have been used to solve different problems using message passing between processes. Message passing is one form of distributed computing using processes, which can be used on clusters of computers or multicore machines.\n",
+        "\n",
+        "In many of these examples, the pattern's name is part of the Java code file's name. You will also see that often the MPI library functions also take on the name of the pattern, and the implementation of those functions themselves contains the pattern that practitioners found themselves using often. These pattern code examples we show you here, dubbed patternlets, are based on original work by Joel Adams:\n",
+        "\n",
+        "Adams, Joel C. \"Patternlets: A Teaching Tool for Introducing Students to Parallel Design Patterns.\" 2015 IEEE International Parallel and Distributed Processing Symposium Workshop. IEEE, 2015.\n",
+        "\n",
+        "To run these examples, first you will need to install the mpi4py library by running this code (this will usually take a while to install the first time):"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "FVgDVtdkxrgc",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "47a671a6-cff0-4b48-935a-e4b2793f5468"
+      },
+      "source": [
+        "!wget https://wsu-courses.s3.amazonaws.com/openmpi411/mpi.jar"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "GJ4ul5SKsfmM"
+      },
+      "source": [
+        "### New to colab and jupyter notebook?\n",
+        "\n",
+        "If you have not used this type of notebook before, these are split into *cells*. The cell you are reading is a text cell, and the cell just above it is also. the cell with [ ] to the left of it is a code cell, which contains Java code or code that can be run as if you are in a linux shell. The latter linux shell commands always begin with an exclamation point, !, as the cell above that contains a wget command, used to download the mpi.jar file.\n",
+        "\n",
+        "You should execute code cells as you follow along in this notebook. Some are designed for you to re-run after changing them. You can run a cell by hovering over the [ ] and clicking on the arrow symbol.\n",
+        "\n",
+        "The symbol in the upper left that looks like three .__ symbols toggles the table of contents. Revealing this enables you to navigate to different pattern examples.\n",
+        "\n",
+        "The triangle next to some text cells below enables collapsing of sections for faster scrolling."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "uryzb1Wy-hlp"
+      },
+      "source": [
+        "# Program structure patterns"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "sdWhWJMLzUIm"
+      },
+      "source": [
+        "## Single Program, Multiple Data\n",
+        "\n",
+        "This code forms the basis of all of the other examples that follow. It is the fundamental way we structure parallel programs today.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "PgRHUlUsSN5u",
+        "outputId": "a43e537e-25a1-4d00-ff54-67ab03777d0e"
+      },
+      "source": [
+        "%%writefile Spmd.java\n",
+        "/* Spmd.java\n",
+        " * ... illustrates the single program multiple data\n",
+        " *      (SPMD) pattern using basic MPI commands\n",
+        " *      and OpenMPI's Java interface.\n",
+        " *\n",
+        " * Joel Adams, Calvin University, November 2019.\n",
+        " *\n",
+        " * Usage: mpirun -np 4 java ./Spmd\n",
+        " *\n",
+        " */\n",
+        "\n",
+        "import mpi.*;\n",
+        "\n",
+        "public class Spmd {\n",
+        "\n",
+        " public static void main(String [] args) throws MPIException {\n",
+        "    MPI.Init(args);\n",
+        "\n",
+        "    int id           = MPI.COMM_WORLD.getRank();\n",
+        "    int numProcesses = MPI.COMM_WORLD.getSize();\n",
+        "    String hostName  = MPI.getProcessorName();\n",
+        "\n",
+        "    String message   = \"Greetings from process #\" + id\n",
+        "                         + \" of \" + numProcesses \n",
+        "                         + \" on \" + hostName + \"\\n\";\n",
+        "    System.out.print(message);\n",
+        "\n",
+        "    MPI.Finalize();\n",
+        "  }\n",
+        "}"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "fRn94fx0WB3h"
+      },
+      "source": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "XLFiYTIJ6ALs"
+      },
+      "source": [
+        "Let's examine the variables created in lines 18-29 carefully.\n",
+        "\n",
+        "1. *comm* The fundamental notion with this type of computing is a *process* running independently on the computer. With one single program like this, we can specify that we want to start several processes, each of which can **communicate**. The mechanism for communication is initialized when the program starts up, and the object that represents the means of using communication between processes is called MPI.COMM_WORLD.\n",
+        "\n",
+        "2. *id* Every process can identify itself with a number. We get that number by asking *comm* for it using Get_rank().\n",
+        "\n",
+        "3. *numProcesses* It is helpful to know haw many processes have started up, because this can be specified differently every time you run this type of program. Asking *comm* for it is done with Get_size().\n",
+        "\n",
+        "4. *myHostName* When you run this code on a cluster of computers, it is sometimes useful to know which computer is running a certain piece of code. A particular computer is often called a 'host', which is why we call this variable myHostName, and get it by asking *comm* to provide it with Get_processor_name().\n",
+        "\n",
+        "These four variables are often used in every MPI program. The first three are often needed for writing correct programs, and the fourth one is often used for debugging and analysis of where certain computations are running.\n",
+        "\n",
+        "Next we see how we can compile and use the mpirun program to execute the above Java code using 4 processes. The value after -np is the number of processes to use when running the file of python code saved when executing the previous code cell."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "zqOAtb4G4-e2",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "fb0e7030-b83d-4ce6-da04-786c4e34fc6b"
+      },
+      "source": [
+        "!javac -cp ./mpi.jar Spmd.java \n",
+        "!mpirun --allow-run-as-root -np 4 java -cp ./mpi.jar Spmd"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "IR2tfQ8v8RVa"
+      },
+      "source": [
+        "The fundamental idea of message passing programs can be illustrated like this:\n",
+        "\n",
+        "![picture](https://drive.google.com/uc?id=1wpQaFiaubIcQBV9Lw_jwOU0y2-K-EChW)\n",
+        "\n",
+        "Each process is set up within a communication network to be able to communicate with every other process via communication links. Each process is set up to have its own number, or id, which starts at 0.\n",
+        "\n",
+        "**Note:** Each process holds its own copies of the above 4 data variables. **So even though there is one single program, it is running multiple times in separate processes, each holding its own data values.** This is the reason for the name of the pattern this code represents: single program, multiple data. The print line at the end of main() represents the multiple different data output produced by each process.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "TSEhP3vv-_yX"
+      },
+      "source": [
+        "## Master-Worker\n",
+        "This is also a very common pattern used in parallel and distributed programming. Here's the sample small illustrative code. Review it and answer this: What is different between this example and the previous one?\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "UlF-_TYc_uKu",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "a00e390d-f76d-41e1-eb7b-d9388abeb592"
+      },
+      "source": [
+        "%%writefile MasterWorker.java\n",
+        "/* MasterWorker.java\n",
+        " * ... illustrates the master-worker pattern\n",
+        " *      using basic MPI commands\n",
+        " *      and OpenMPI's Java interface.\n",
+        " *\n",
+        " * Joel Adams, Calvin University, November 2019.\n",
+        " *\n",
+        " * Usage: mpirun -np 4 java ./MasterWorker\n",
+        " *\n",
+        " */\n",
+        "\n",
+        "import mpi.*;\n",
+        "\n",
+        "public class MasterWorker {\n",
+        "\n",
+        " public static final int MASTER = 0;\n",
+        "\n",
+        " public static void main(String [] args) throws MPIException {\n",
+        "    MPI.Init(args);\n",
+        "\n",
+        "    int id           = MPI.COMM_WORLD.getRank();\n",
+        "    int numProcesses = MPI.COMM_WORLD.getSize();\n",
+        "    String hostName  = MPI.getProcessorName();\n",
+        "    String message   = \"Greetings from \";\n",
+        "\n",
+        "    if (id == MASTER) {\n",
+        "       message += \"the master, #\" + id\n",
+        "                   + \" (\" + hostName + \")\"\n",
+        "                   + \" of \" + numProcesses + \"\\n\";\n",
+        "    } else {\n",
+        "       message += \"a worker, #\" + id\n",
+        "                   + \" (\" + hostName + \")\"\n",
+        "                   + \" of \" + numProcesses + \"\\n\";\n",
+        "    }\n",
+        "\n",
+        "    System.out.print(message);\n",
+        "\n",
+        "    MPI.Finalize();\n",
+        "  }\n",
+        "}\n"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "FQ0rjAxS_9xK"
+      },
+      "source": [
+        "The answer to the above question illustrates what we can do with this pattern: based on the process id, we can have one process carry out something different than the others. This concept is used a lot as a means to coordinate activities, where one process, often called the master, has the responsibility of handing out work and keeping track of results. We will see this in later examples.\n",
+        "\n",
+        "**Note:** By convention, the master coordinating process is usually the process number 0."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "j8HeRMx-APS2",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "2078fe6f-e866-4b84-91ac-506b2a3c0af9"
+      },
+      "source": [
+        "!javac -cp ./mpi.jar MasterWorker.java \n",
+        "!mpirun --allow-run-as-root -np 4 java -cp ./mpi.jar MasterWorker"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "-Eyj6sa7GoXu"
+      },
+      "source": [
+        "### Exercises:\n",
+        "\n",
+        "- Rerun, using varying numbers of processes from 1 through 8 (i.e., vary the argument after -np).\n",
+        "- Explain what stays the same and what changes as the number of processes changes."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "v1uIEnUS-JGG"
+      },
+      "source": [
+        "# Decomposition using parallel for loop patterns\n",
+        "\n",
+        "The most common way to complete a repeated task in any program language is a loop. We use loops because we want to do a certain number of tasks, very often because we want to work on a set of data elements found in a list or an array, or some other data structure. If the work to be done in each loop is independent of previous iterations, we can use separate processes to do parts of the loop independently. This program structure pattern is called the parallel for loop pattern, which is an implementation strategy for decomposition of the work to be done into smaller parts."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "kVWqN3EhJFbJ"
+      },
+      "source": [
+        "## Parallel Loop Split into Equal Sized Chunks\n",
+        "\n",
+        "In the code below, notice the use of the variable called `REPS`. This is designed to be the total amount or work, or repetitions, that the for loop is accomplishing. This particular code is designed so that if those repetitions do not divide equally by the number of processes, then the program will stop with a warning message printed by the master process.\n",
+        "\n",
+        "Remember that because this is still also a SPMD program, all processes execute the code in the part of the if statement that evaluates to True. Each process has its own id, and we can determine how many processes there are, so we can choose where in the overall number of REPs of the loop each process will execute."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "3OpxV7pnJ_u2",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "1d7ab552-a45b-4690-e6ed-6220eb156b63"
+      },
+      "source": [
+        "%%writefile ParallelLoopEqualChunks.java\n",
+        "/* ParallelLoopEqualChunks.java\n",
+        " * ... illustrates the parallel loop pattern in OpenMPI+Java,\n",
+        " *      in which processes perform the loop's iterations in equal-sized 'chunks'\n",
+        " *      (preferable when loop iterations access memory/cache locations) ...\n",
+        " *\n",
+        " * Joel Adams, Calvin University, November 2019.\n",
+        " *  with error-handling logic by Libby Shoop, Macalester College, 2017\n",
+        " *\n",
+        " * Usage: mpirun -np 4 java ./ParallelLoopEqualChunks\n",
+        " *\n",
+        " * Exercise:\n",
+        " * - Compile and run, varying N: 1, 2, 4, and 8\n",
+        " * - Change REPS to 16, save, recompile, rerun, varying N again.\n",
+        " * - Explain how this pattern divides the iterations of the loop\n",
+        " *    among the processes.\n",
+        " * - What if REPS is not evenly divisible by N?\n",
+        " *    What would be a better way to handle that case?\n",
+        " */\n",
+        "\n",
+        "import mpi.*;\n",
+        "\n",
+        "public class ParallelLoopEqualChunks {\n",
+        "\n",
+        " public static final int REPS = 8;\n",
+        " public static final int MASTER = 0;\n",
+        "\n",
+        " public static void main(String [] args) throws MPIException {\n",
+        "    MPI.Init(args);\n",
+        "\n",
+        "    int id           = MPI.COMM_WORLD.getRank();\n",
+        "    int numProcesses = MPI.COMM_WORLD.getSize();\n",
+        "    String message   = \"\";\n",
+        "\n",
+        "    // For this first example, ensure that the REPS can be evenly divided by the\n",
+        "    // number of processes and that the number of processes doesn't exceed REPS.\n",
+        "    // If that is not the case, have the master print an error msg and stop.\n",
+        "    if ((REPS % numProcesses) > 0 || numProcesses > REPS) {\n",
+        "      if (id == MASTER) {\n",
+        "          System.out.print(\"\\nPlease run with -np divisible by and less than or equal to \"\n",
+        "                  +  REPS + \"\\n\\n\");\n",
+        "      }\n",
+        "    } else {\n",
+        "      int chunkSize = REPS / numProcesses;      // find chunk size\n",
+        "      int start = id * chunkSize;               // find starting index\n",
+        "      int stop = start + chunkSize;             // find stopping index\n",
+        "\n",
+        "      for (int i = start; i < stop; i++) {      // iterate through our range\n",
+        "          message = \"Process \" + id + \" is performing iteration \" + i + \"\\n\";\n",
+        "          System.out.print(message);\n",
+        "      }\n",
+        "    }\n",
+        "\n",
+        "    MPI.Finalize();\n",
+        "  }\n",
+        "}\n"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "BBshPRYXLLhJ",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "113155eb-a2d7-4ac0-ca6f-22fe20f550c2"
+      },
+      "source": [
+        "!javac -cp ./mpi.jar ParallelLoopEqualChunks.java \n",
+        "!mpirun --allow-run-as-root -np 4 java -cp ./mpi.jar ParallelLoopEqualChunks"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "LJ_ThE3-KthZ"
+      },
+      "source": [
+        "### Exercises\n",
+        "\n",
+        "- Run, using these numbers of processes, N: 1, 2, 4, and 8 (i.e., vary the  argument to -np).\n",
+        "- Change REPS to 16 in the code and rerun it. Then rerun with mpirun, varying N again.\n",
+        "- Explain how this pattern divides the iterations of the loop among the processes.\n",
+        "\n",
+        "Which of the following is the correct assignment of loop iterations to processes for this code, when REPS is 8 and numProcesses is 4?\n",
+        "\n",
+        "\n",
+        "![picture](https://drive.google.com/uc?id=1eUsjxYdWXWqThO_rdLO91HaLqBLAAh_S)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "_okom_QiQeHe"
+      },
+      "source": [
+        "## Parallel for Loop Program Structure: chunks of 1\n",
+        "\n",
+        "In the code below, we again use the variable called `REPS` for the total amount or work, or repetitions, that the for loop is accomplishing. This particular code is designed so that the number of repetitions should be more than or equal to the number of processes requested.\n",
+        ".. note:: Typically in real problems, the number of repetitions is much higher than the number of processes. We keep it small here to illustrate what is happening.\n",
+        "\n",
+        "Like the last example all processes execute the code in the part of the if statement that evaluates to True. Note that in the for loop in this case we simply have process whose id is 0 start at iteration 0, then skip to 0 + numProcesses for its next iteration, and so on. Similarly, process 1 starts at iteration 1, skipping next to 1+ numProcesses, and continuing until REPs is reached. Each process performs similar single 'slices' or 'chunks of size 1' of the whole loop.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "15B2xax5RXEY",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "47935fb4-317a-4940-90a9-ee0a687083a3"
+      },
+      "source": [
+        "%%writefile ParallelLoopChunksOf1.java\n",
+        "/* ParallelLoopChunksOf1.java\n",
+        " * ... illustrates the parallel loop pattern in OpenMPI+Java,\n",
+        " *      in which processes perform the loop's iterations in 'chunks'\n",
+        " *      of size 1 (simple, and useful when loop iterations\n",
+        " *      do not access memory/cache locations) ...\n",
+        " * Note this is much simpler than the 'equal chunks' loop.\n",
+        " *\n",
+        " * Joel Adams, Calvin University, November 2019.\n",
+        " *\n",
+        " * Usage: mpirun -np 4 java ./ParallelLoopChunksOf1\n",
+        " *\n",
+        " * Exercise:\n",
+        " * - Compile and run, varying N: 1, 2, 3, 4, 5, 6, 7, 8\n",
+        " * - Change REPS to 16, save, recompile, rerun, varying N again.\n",
+        " * - Explain how this pattern divides the iterations of the loop\n",
+        " *    among the processes.\n",
+        " */\n",
+        "\n",
+        "import mpi.*;\n",
+        "\n",
+        "public class ParallelLoopChunksOf1 {\n",
+        "\n",
+        " public static final int REPS = 8;\n",
+        " public static final int MASTER = 0;\n",
+        "\n",
+        " public static void main(String [] args) throws MPIException {\n",
+        "    MPI.Init(args);\n",
+        "\n",
+        "    int id           = MPI.COMM_WORLD.getRank();\n",
+        "    int numProcesses = MPI.COMM_WORLD.getSize();\n",
+        "    String message   = \"\";\n",
+        "\n",
+        "    if (numProcesses > REPS) {\n",
+        "      if (id == MASTER) {\n",
+        "          System.out.print(\"\\nPlease run with -np less than or equal to \"\n",
+        "                  +  REPS + \"\\n\\n\");\n",
+        "      }\n",
+        "    } else {\n",
+        "      for (int i = id; i < REPS; i += numProcesses) { \n",
+        "          message = \"Process \" + id + \" is performing iteration \" + i + \"\\n\";\n",
+        "          System.out.print(message);\n",
+        "      }\n",
+        "    }\n",
+        "\n",
+        "    MPI.Finalize();\n",
+        "  }\n",
+        "}\n"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "t0ewx6nLSLgV",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "2a2f9d94-849c-4de3-e8e5-c9b9f2940b5f"
+      },
+      "source": [
+        "!javac -cp ./mpi.jar ParallelLoopChunksOf1.java \n",
+        "!mpirun --allow-run-as-root -np 4 java -cp ./mpi.jar ParallelLoopChunksOf1"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Vww7AO93S8QD"
+      },
+      "source": [
+        "### Exercises\n",
+        "- Run, using these numbers of processes, N: 1, 2, 4, and 8\n",
+        "- Compare source code to output.\n",
+        "- Change REPS to 16, save, rerun, varying N again.\n",
+        "- Explain how this pattern divides the iterations of the loop among the processes.\n",
+        "\n",
+        "Which of the following is the correct assignment of loop iterations to processes for this code, when REPS is 8 and numProcesses is 4?\n",
+        "\n",
+        "\n",
+        "![picture](https://drive.google.com/uc?id=1eUsjxYdWXWqThO_rdLO91HaLqBLAAh_S)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "sGj_Em7xToeB"
+      },
+      "source": [
+        "# Point to point communication: the message passing pattern\n",
+        "\n",
+        "The fundamental basis of coordination between independent processes is point-to-point communication between processes through the communication links in the MPI.COMM_WORLD. The form of communication is called message passing, where one process **sends** data to another one, who in turn must **receive** it from the sender. This is illustrated as follows:\n",
+        "\n",
+        "![picture](https://drive.google.com/uc?id=1WJcOXq6Dn5TKF9Lng8r18_y2b23tHFe8)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "bXSiO5dGuJda"
+      },
+      "source": [
+        "## Message Passing Pattern: Key Problem\n",
+        "\n",
+        "The following code represents a common error that many programmers have inadvertently placed in their code. The concept behind this program is that we wish to use communication between pairs of processes, like this:\n",
+        "\n",
+        "![picture](https://drive.google.com/uc?id=1UJ2acj6XzphD2W6gnutNF2YGp6wU529Z)\n",
+        "\n",
+        "For message passing to work between a pair of processes, one must send and the other must receive. If we wish to **exchange** data, then each process will need to perform both a send and a receive.\n",
+        "The idea is that process 0 will send data to process 1, who will receive it from process 0. Process 1 will also send some data to process 0, who will receive it from process 1. Similarly, processes 2 and 3 will exchange messages: process 2 will send data to process 3, who will receive it from process 2. Process 3 will also send some data to process 2, who will receive it from process 3.\n",
+        "\n",
+        "If we have more processes, we still want to pair up processes together to exchange messages. The mechanism for doing this is to know your process id. If your id is odd (1, 3 in the above diagram), you will send and receive from your neighbor whose id is id - 1. If your id is even (0, 2), you will send and receive from your neighbor whose id is id + 1. This should work even if we add more than 4 processes, as long as the number of processes is divisible by 2.\n",
+        "\n",
+        "![warning sign](https://drive.google.com/uc?id=1SEqDBTBSKwNVXzn-zueWa7fBCm5b1_MB)\n",
+        "**Warning** There is a problem with the following code called *deadlock*. This happens when every process is waiting on an action from another process. The program cannot complete. **To stop the program, choose the small square that appears after you choose to run the mpirun cell.**\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "A_-_ypqDvAM0",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "a59a1fa5-100e-4a58-91d1-a1a724e5d874"
+      },
+      "source": [
+        "%%writefile MessagePassingDeadlock.java\n",
+        "/* MessagePassing.java\n",
+        " * ... illustrates how use of MPI's send and receive commands\n",
+        " *      can lead to deadlock.\n",
+        " *\n",
+        " * Goal: Have MPI processes pair up and exchange their id numbers.\n",
+        " *\n",
+        " * Note: Values are sent/received in Java using arrays or buffers.\n",
+        " *       Buffers are preferred b/c they work for all communication calls.\n",
+        " *\n",
+        " * Joel Adams, Calvin University, November 2019,\n",
+        " *  with error-handling from Hannah Sonsalla, Macalester College 2017.\n",
+        " *\n",
+        " * Usage: mpirun -np 4 java ./MessagePassing\n",
+        " *\n",
+        " * Exercise:\n",
+        " * - Compile, then run using 1 process, then 2 processes.\n",
+        " *    (Use Cntl-c to terminate.)\n",
+        " * - Use source code to trace execution.\n",
+        " * - Why does this fail?\n",
+        "\n",
+        " */\n",
+        "\n",
+        "import mpi.*;\n",
+        "import java.nio.IntBuffer;\n",
+        "\n",
+        "public class MessagePassingDeadlock {\n",
+        "\n",
+        " public static void main(String [] args) throws MPIException {\n",
+        "    MPI.Init(args);\n",
+        "\n",
+        "    Comm comm         = MPI.COMM_WORLD;\n",
+        "    int numProcesses  = comm.getSize();\n",
+        "    int id            = comm.getRank();\n",
+        "\n",
+        "    if ( numProcesses <= 1 || (numProcesses % 2) != 0)  {\n",
+        "        if (id == MASTER) {\n",
+        "            System.out.print(\"\\nPlease run this program using -np N where N is positive and even.\\n\\n\");\n",
+        "        }\n",
+        "    } else {\n",
+        "        IntBuffer sendBuf = MPI.newIntBuffer(1);\n",
+        "        sendBuf.put(id);\n",
+        "        IntBuffer receiveBuf = MPI.newIntBuffer(1);\n",
+        "\n",
+        "        if ( odd(id) ) { // odd processes receive from their 'left' neighbor, then send\n",
+        "            comm.recv(receiveBuf, 1, MPI.INT, id-1, 0); \n",
+        "            comm.send(sendBuf, 1, MPI.INT, id-1, 0);\n",
+        "        } else {         // even processes receive from their 'right' neighbor, then send\n",
+        "            comm.recv(receiveBuf, 1, MPI.INT, id+1, 0); \n",
+        "            comm.send(sendBuf, 1, MPI.INT, id+1, 0);\n",
+        "        }\n",
+        "\n",
+        "        String message = \"Process \" + id + \" sent '\" + sendBuf.get(0)\n",
+        "                         + \"' and received '\" + receiveBuf.get(0) + \"'\\n\";\n",
+        "        System.out.print(message);\n",
+        "    }\n",
+        "\n",
+        "    MPI.Finalize();\n",
+        "  }\n",
+        "\n",
+        "  public static boolean odd(int number) { return number % 2 != 0; }\n",
+        "\n",
+        "  private static final int MASTER = 0;\n",
+        "}\n"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "VbbAxy7vvYwW"
+      },
+      "source": [
+        "!javac -cp ./mpi.jar MessagePassingDeadlock.java \n",
+        "!mpirun --allow-run-as-root -np 4 java -cp ./mpi.jar MessagePassingDeadlock"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "0MLayXixxraM"
+      },
+      "source": [
+        "![warning sign](https://drive.google.com/uc?id=1SEqDBTBSKwNVXzn-zueWa7fBCm5b1_MB)Remember,**To stop the program, choose the small square that appears after you choose to run the mpirun cell.**"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "49L8NojO6axL"
+      },
+      "source": [
+        "#### What causes the deadlock?\n",
+        "\n",
+        "Each process, regardless of its id, will execute a receive request first. In this model, recv is a **blocking** function- it will not continue until it gets data from a send. So every process is blocked waiting to receive a message.\n",
+        "\n",
+        "#### Can you think of how to fix this problem?\n",
+        "\n",
+        "Since recv is a **blocking** function, we need to have some processes send first, while others correspondingly recv first from those who send first. This provides coordinated exchanges.\n",
+        "\n",
+        "Go to the next example to see the solution.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "XxKI85d8LLll"
+      },
+      "source": [
+        "## Message Passing Patterns: avoiding deadlock\n",
+        "\n",
+        "Let's look at a few more correct message passing examples.\n",
+        "\n",
+        "### Fix the Deadlock\n",
+        "\n",
+        "To fix deadlock of the previous example, we coordinate the communication between pairs of processes so that there is an ordering of sends and receives between them.\n",
+        "\n",
+        "![Important symbol](https://drive.google.com/uc?id=1AWRLAqeaqi7SG7PHyOVywZRuMDK9Z2_s)**Important:** The new code corrects deadlock with a simple change: odd process sends first, even process receives first. *This is the proper pattern for exchanging data between pairs of processes.*"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "OO8N49wuL0fR",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "566deccb-fad7-44db-fae9-bd92340ba25c"
+      },
+      "source": [
+        "%%writefile MessagePassing.java\n",
+        "/* MessagePassing.java\n",
+        " * ... illustrates the use of MPI's send and receive commands,\n",
+        " *      using OpenMPI's Java interface.\n",
+        " *\n",
+        " * Goal: Have MPI processes pair up and exchange their id numbers.\n",
+        " *\n",
+        " * Note: Values are sent/received in Java using arrays or buffers.\n",
+        " *       Buffers are preferred b/c they work for all communication calls.\n",
+        " *\n",
+        " * Joel Adams, Calvin University, November 2019,\n",
+        " *  with error-handling from Hannah Sonsalla, Macalester College 2017.\n",
+        " *\n",
+        " * Usage: mpirun -np 4 java ./MessagePassing\n",
+        " *\n",
+        " * Exercise:\n",
+        " * - Compile and run, using N = 4, 6, 8, and 10 processes.\n",
+        " * - Use source code to trace execution.\n",
+        " * - Explain what each process:\n",
+        " * -- sends\n",
+        " * -- receives\n",
+        " * -- outputs.\n",
+        " * - Run using N = 5 processes. What happens?\n",
+        " */\n",
+        "\n",
+        "import mpi.*;\n",
+        "import java.nio.IntBuffer;\n",
+        "\n",
+        "public class MessagePassing {\n",
+        "\n",
+        " public static void main(String [] args) throws MPIException {\n",
+        "    MPI.Init(args);\n",
+        "\n",
+        "    Comm comm         = MPI.COMM_WORLD;\n",
+        "    int numProcesses  = comm.getSize();\n",
+        "    int id            = comm.getRank();\n",
+        "\n",
+        "    if ( numProcesses <= 1 || (numProcesses % 2) != 0)  {\n",
+        "        if (id == MASTER) {\n",
+        "            System.out.print(\"\\nPlease run this program using -np N where N is positive and even.\\n\\n\");\n",
+        "        }\n",
+        "    } else {\n",
+        "        IntBuffer sendBuf = MPI.newIntBuffer(1);\n",
+        "        sendBuf.put(id);\n",
+        "        IntBuffer receiveBuf = MPI.newIntBuffer(1);\n",
+        "\n",
+        "        if ( odd(id) ) { // odd processes send, then receive\n",
+        "            comm.send(sendBuf, 1, MPI.INT, id-1, 0);\n",
+        "            comm.recv(receiveBuf, 1, MPI.INT, id-1, 0); \n",
+        "        } else {         // even processes receive then send\n",
+        "            comm.recv(receiveBuf, 1, MPI.INT, id+1, 0); \n",
+        "            comm.send(sendBuf, 1, MPI.INT, id+1, 0);\n",
+        "        }\n",
+        "\n",
+        "        String message = \"Process \" + id + \" sent '\" + sendBuf.get(0)\n",
+        "                         + \"' and received '\" + receiveBuf.get(0) + \"'\\n\";\n",
+        "        System.out.print(message);\n",
+        "    }\n",
+        "\n",
+        "    MPI.Finalize();\n",
+        "  }\n",
+        "\n",
+        "  public static boolean odd(int number) { return number % 2 != 0; }\n",
+        "\n",
+        "  private static final int MASTER = 0;\n",
+        "}\n"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "0zl-Ms_kMMql",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "78601a4f-64b7-4142-d2ec-dc21c58b6466"
+      },
+      "source": [
+        "!javac -cp ./mpi.jar MessagePassing.java \n",
+        "!mpirun --allow-run-as-root -np 4 java -cp ./mpi.jar MessagePassing"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "UKgBEDizMkRM"
+      },
+      "source": [
+        "### Exercise\n",
+        "\n",
+        "- Run, using N = 4, 6, 8, and 10 processes. (Note what happens if you use an odd number instead.)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Y4ybJILhM137"
+      },
+      "source": [
+        "## Sending data structures\n",
+        "This next example illustrates that we can exchange different lists of data between processes.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "grQWl82lNWsn",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "fc82d10f-3118-4f4d-c480-21e6e68fcab6"
+      },
+      "source": [
+        "%%writefile MessagePassing2.java\n",
+        "/* MessagePassing2.java\n",
+        " * ... illustrates the use of MPI's send and receive commands\n",
+        " *      to send Strings via CharBuffers, using OpenMPI's Java interface.\n",
+        " *\n",
+        " * Goal: Have MPI processes pair up and exchange their host-names.\n",
+        " *\n",
+        " * Note: Values are sent/received in Java using arrays or buffers.\n",
+        " *       Buffers are preferred as they work for both blocking and\n",
+        " *        non-blocking communication calls.\n",
+        " *       This example uses chars but the same approach works with numbers.\n",
+        " *\n",
+        " * Joel Adams, Calvin University, November 2019;\n",
+        " *  error-handling adapted from Hannah Sonsalla, Macalester College 2017.\n",
+        " *\n",
+        " * Usage: mpirun -np 4 java ./MessagePassing2\n",
+        " *\n",
+        " * Exercise:\n",
+        " * - Compile and run, using N = 1, 2, 4, and 8 processes.\n",
+        " * - Use source code to trace execution.\n",
+        " * - Compare to MessagePassing.java; note send-receive differences.\n",
+        " */\n",
+        "\n",
+        "import mpi.*;\n",
+        "import java.nio.CharBuffer;\n",
+        "\n",
+        "public class MessagePassing2 {\n",
+        "\n",
+        " public static void main(String [] args) throws MPIException {\n",
+        "    MPI.Init(args);\n",
+        "\n",
+        "    Comm comm         = MPI.COMM_WORLD;\n",
+        "    int numProcesses  = comm.getSize();\n",
+        "    int id            = comm.getRank();\n",
+        "\n",
+        "    if ( numProcesses <= 1 || (numProcesses % 2) != 0)  {\n",
+        "        if (id == MASTER) {\n",
+        "            System.out.print(\"\\nPlease run this program using -np N where N is positive and even.\\n\\n\");\n",
+        "        }\n",
+        "        MPI.Finalize();\n",
+        "        System.exit(0);\n",
+        "    } \n",
+        "\n",
+        "    String hostName   = MPI.getProcessorName();\n",
+        "    CharBuffer sendBuf = MPI.newCharBuffer(BUFFER_SIZE);\n",
+        "    //sendBuf.put(hostName);  // this builds and is supposed to work but doesn't,\n",
+        "                               // (UTF-16 vs UTF-8?) so we'll do it the long way\n",
+        "    for (int i = 0; i < hostName.length(); ++i) {\n",
+        "         sendBuf.put(i, hostName.charAt(i));\n",
+        "    }\n",
+        "\n",
+        "    CharBuffer receiveBuf = MPI.newCharBuffer(BUFFER_SIZE);\n",
+        "    Status status;\n",
+        "\n",
+        "    if ( odd(id) ) { // odd processes send, then receive\n",
+        "        comm.send(sendBuf, hostName.length(), MPI.CHAR, id-1, 0);\n",
+        "        status = comm.recv(receiveBuf, BUFFER_SIZE, MPI.CHAR, id-1, 0); \n",
+        "    } else {         // even processes receive then send\n",
+        "        status = comm.recv(receiveBuf, BUFFER_SIZE, MPI.CHAR, id+1, 0); \n",
+        "        comm.send(sendBuf, hostName.length(), MPI.CHAR, id+1, 0);\n",
+        "    }\n",
+        "\n",
+        "    String sentString = sendBuf.toString();\n",
+        "    String receivedString = receiveBuf.toString();\n",
+        "    String message = \"Process \" + id + \" sent '\" + hostName\n",
+        "                      + \"' and received '\" + receivedString + \"'\\n\";\n",
+        "    System.out.print(message);\n",
+        "\n",
+        "    MPI.Finalize();\n",
+        "  }\n",
+        "\n",
+        "  private static boolean odd(int number) { return number % 2 != 0; }\n",
+        "\n",
+        "  private static final int MASTER = 0;\n",
+        "  private static final int BUFFER_SIZE = 256;\n",
+        "}\n"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "9zYlFcz8Nnx1",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "88b32775-ddad-4b75-c2c1-2d7b01ad0b09"
+      },
+      "source": [
+        "!javac -cp ./mpi.jar MessagePassing2.java \n",
+        "!mpirun --allow-run-as-root -np 4 java -cp ./mpi.jar MessagePassing2"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "lFx0VyZzN1Aw"
+      },
+      "source": [
+        "### Exercise\n",
+        "\n",
+        "- Run, using N = 4, 6, 8, and 10 processes. \n",
+        "- In the above code, locate where the list of elements to be sent is being made by each process. What is different about each list per process?\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "eJQfgyqlOTCr"
+      },
+      "source": [
+        "## Ring of passed messages\n",
+        "Another pattern that appears in message passing programs is to use a ring of processes, where messages get sent in this fashion:\n",
+        "\n",
+        "![picture of ring of message passing](https://drive.google.com/uc?id=16VMF9t8nD3JcVehFvs4dbzIiU5eDuZbG)\n",
+        "\n",
+        "When we have 4 processes, the idea is that process 0 will send data to process 1, who will receive it from process 0 and then send it to process 2, who will receive it from process 1 and then send it to process 3, who will receive it from process 2 and then send it back around to process 0."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "n4PQNTd3PAGR",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "ddff9853-3d7f-479f-f043-0e616885d36d"
+      },
+      "source": [
+        "%%writefile MessagePassing3.java\n",
+        "/* MessagePassing3.java\n",
+        " * ... illustrates the use of MPI's send and receive commands\n",
+        " *      in combination with the master-worker pattern.\n",
+        " *\n",
+        " * Goal: The master process sends its id to process 1\n",
+        " *        and receives a buffer of ids from process N-1.\n",
+        " *       Every other process i receives a buffer of ids from process i-1,\n",
+        " *        appends its id to the buffer, and sends the buffer to process (i+1)%N.\n",
+        " *\n",
+        " * Joel Adams, Calvin University, November 2019,\n",
+        " *\n",
+        " * Usage: mpirun -np 4 java ./MessagePassing3\n",
+        " *\n",
+        " * Exercise:\n",
+        " * - Compile and run, varying N from 1-8.\n",
+        " * - Explain the behavior you observe.\n",
+        " */\n",
+        "\n",
+        "import mpi.*;\n",
+        "import java.nio.IntBuffer;\n",
+        "\n",
+        "public class MessagePassing3 {\n",
+        "\n",
+        " public static void main(String [] args) throws MPIException {\n",
+        "    MPI.Init(args);\n",
+        "\n",
+        "    Comm comm         = MPI.COMM_WORLD;\n",
+        "    int numProcesses  = comm.getSize();\n",
+        "    int id            = comm.getRank();\n",
+        "\n",
+        "    if ( numProcesses <= 1 )  {\n",
+        "        if (id == MASTER) {\n",
+        "            System.out.print(\"\\nPlease run this program using -np N where N is at least 2.\\n\\n\");\n",
+        "        }\n",
+        "        MPI.Finalize();\n",
+        "        System.exit(0);\n",
+        "    } \n",
+        "\n",
+        "    IntBuffer sendBuf = MPI.newIntBuffer(BUFFER_SIZE);\n",
+        "    IntBuffer receiveBuf = MPI.newIntBuffer(BUFFER_SIZE);\n",
+        "    Status status;\n",
+        "\n",
+        "    if ( id == MASTER ) {                              // MASTER:\n",
+        "        sendBuf.put(0, id);                            // 1. put id in buffer\n",
+        "        comm.send(sendBuf,                             // 2. send: buffer,\n",
+        "                        1,                             //          number of values,\n",
+        "                        MPI.INT,                       //          type of values,\n",
+        "                        id+1,                          //          destination id,\n",
+        "                        0);                            //          tag.\n",
+        "        status = comm.recv(receiveBuf,                 // 3. recv: buffer,\n",
+        "                            BUFFER_SIZE,               //          buffer capacity,\n",
+        "                            MPI.INT,                   //          type of values,\n",
+        "                            numProcesses-1,            //          sender id,\n",
+        "                            0);                        //          tag.\n",
+        "        int valuesReceived = status.getCount(MPI.INT); // 4. how many did we get?\n",
+        "        output(receiveBuf, valuesReceived);            // 5. output what we got.\n",
+        "    } else {                                           // WORKERS:\n",
+        "        status = comm.recv(receiveBuf,                 // 1. receive: buffer,\n",
+        "                            BUFFER_SIZE,               //             buffer capacity,\n",
+        "                            MPI.INT,                   //             type of values,\n",
+        "                            id-1,                      //             sender id,\n",
+        "                             0);                       //             tag.\n",
+        "        int valuesReceived = status.getCount(MPI.INT); // 2. how many did we get?\n",
+        "        output(receiveBuf, valuesReceived);            // 3. output what we got.\n",
+        "        receiveBuf.put(valuesReceived, id);            // 4. append id to buffer\n",
+        "        comm.send(receiveBuf,                          // 5. send: buffer,\n",
+        "                   valuesReceived+1,                   //          number of values,\n",
+        "                   MPI.INT,                            //          type of values,\n",
+        "                   (id+1) % numProcesses,              //          destination id,\n",
+        "                    0);                                //          tag.\n",
+        "    }\n",
+        "\n",
+        "    MPI.Finalize();\n",
+        "  }\n",
+        "\n",
+        "  /* utility to print an IntBuffer with descriptive labels.\n",
+        "   * @param: buf, an IntBuffer.\n",
+        "   * @param: size, the number of ints in IntBuffer\n",
+        "   *          (b/c IntBuffer has no length() method,\n",
+        "   *            whose bright idea was that?).\n",
+        "   * POST: The ints in buf have been displayed on System.out,\n",
+        "   *        preceded by spaces, and with a newline at the end.\n",
+        "   */\n",
+        "  private static void output(IntBuffer buf, int size) throws MPIException {\n",
+        "      System.out.printf(\"Process %d of %d received:\",\n",
+        "                          MPI.COMM_WORLD.getRank(),\n",
+        "                          MPI.COMM_WORLD.getSize());\n",
+        "      for (int i = 0; i < size; ++i) {\n",
+        "          System.out.print( \" \" );\n",
+        "          System.out.print( buf.get(i) );\n",
+        "      }\n",
+        "      System.out.print(\"\\n\");\n",
+        "  }\n",
+        "\n",
+        "  private static final int MASTER = 0;\n",
+        "  private static final int BUFFER_SIZE = 256;\n",
+        "}\n"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "iGTpIE-pPRIq",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "7026fadc-8767-4774-d5cb-46afd668c8c8"
+      },
+      "source": [
+        "!javac -cp ./mpi.jar MessagePassing3.java \n",
+        "!mpirun --allow-run-as-root -np 4 java -cp ./mpi.jar MessagePassing3"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "o6bvSqgMPeyt"
+      },
+      "source": [
+        "### Exercises\n",
+        "- Run, using N = from 1 through 8 processes.\n",
+        "- Make sure that you can trace how the code generates the output that you see.\n",
+        "- How is the finishing of the 'ring' completed, where the last process determines that it should send back to process 0?"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "bPqOxvbK5qSx"
+      },
+      "source": [
+        "# Collective Communication: Broadcast pattern\n",
+        "There are many cases when a master process obtains or creates data that needs to be sent to all of the other processes. There is a special pattern for this called **broadcast**. You will see examples of the master sending different types of data to each of the other processes."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "57wzDFu2xxvW"
+      },
+      "source": [
+        "## Broadcast from master to workers\n",
+        "\n",
+        "We will look at three types of data that can be created in the master and sent to the workers. Rather than use send and receive, we will use a special new function called bcast.\n",
+        "\n",
+        "![Important symbol](https://drive.google.com/uc?id=1AWRLAqeaqi7SG7PHyOVywZRuMDK9Z2_s) **Note:** In each code example, note how the master does one thing, and the workers do another, but **all of the processes execute the bcast function.**\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "n3eZ1sN1yVsK"
+      },
+      "source": [
+        "### Broadcast an integer\n",
+        "\n",
+        "Find the place in this code where the data is being broadcast to all of the processes. Match the prints to the output you observe when you run it."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "HVx87ecmynYO",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "eb94261d-4033-4e6a-946f-7efd0080c2cc"
+      },
+      "source": [
+        "%%writefile Broadcast.java\n",
+        "/* Broadcast.java\n",
+        " * ... illustrates the use of MPI's broadcast command with a scalar value.\n",
+        " *\n",
+        " * Note: This version uses an IntBuffer of length 1 to store the scalar.\n",
+        " *\n",
+        " * Goal: The master process reads an 'answer' value from a file\n",
+        " *        and broadcasts it to all the other processes.\n",
+        " *       Each process outputs its 'answer' value before and after\n",
+        " *        the broadcast.\n",
+        " *\n",
+        " * Joel Adams, Calvin University, November 2019,\n",
+        " *\n",
+        " * Usage: mpirun -np 4 java ./Broadcast\n",
+        " *\n",
+        " * Exercise:\n",
+        " * - Compile, then run several times,\n",
+        " *     using 2, 4, and 8 processes\n",
+        " * - Use source code to trace execution and output\n",
+        " *     (noting contents of file \"data.txt\");\n",
+        " * - Explain behavior/effect of MPI_Bcast().\n",
+        " */\n",
+        "\n",
+        "import java.io.File;\n",
+        "import java.io.FileNotFoundException;\n",
+        "import java.util.Scanner;\n",
+        "import java.nio.IntBuffer;\n",
+        "import mpi.*;\n",
+        "\n",
+        "public class Broadcast {\n",
+        "\n",
+        " public static void main(String [] args) throws MPIException {\n",
+        "    MPI.Init(args);\n",
+        "\n",
+        "    Comm comm         = MPI.COMM_WORLD;\n",
+        "    int id            = comm.getRank();\n",
+        "\n",
+        "    IntBuffer answerBuf = MPI.newIntBuffer(1);\n",
+        "\n",
+        "    if ( id == MASTER ) {                      // MASTER: read data from file\n",
+        "        int answer = 42;\n",
+        "        answerBuf.put(answer);\n",
+        "    }\n",
+        "\n",
+        "    String beforeMsg = \"BEFORE the broadcast, process \" + id\n",
+        "                       + \"'s answer is: \" + answerBuf.get(0) + \"\\n\";\n",
+        "    System.out.print(beforeMsg);               // all: output 'before' values\n",
+        "\n",
+        "    printSeparator(\"----\", id);\n",
+        "\n",
+        "    comm.bcast(answerBuf, 1, MPI.INT, 0);      // all: participate in broadcast\n",
+        "\n",
+        "    String afterMsg = \"AFTER the broadcast, process \" + id\n",
+        "                       + \"'s answer is: \" + answerBuf.get(0) + \"\\n\";\n",
+        "    System.out.print(afterMsg);                // all: output 'after' values\n",
+        "\n",
+        "    MPI.Finalize();\n",
+        "  }\n",
+        "\n",
+        "  /* utility to print a separator string between the 'before' and 'after' parts.\n",
+        "   * @param: separator, a String.\n",
+        "   * @param: id, the rank of this MPI process.\n",
+        "   * POST: the master has printed the separator to System.out.\n",
+        "   */\n",
+        "  public static void printSeparator(String separator, int id) throws MPIException {\n",
+        "     MPI.COMM_WORLD.barrier();\n",
+        "     if (id == MASTER) { System.out.println(separator); }\n",
+        "     MPI.COMM_WORLD.barrier();\n",
+        "  }\n",
+        "\n",
+        "  private static final int MASTER = 0;\n",
+        "}\n"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "SK268l7SzB5e",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "96df228c-f1c5-411b-dff6-d948f856b45a"
+      },
+      "source": [
+        "!javac -cp ./mpi.jar Broadcast.java \n",
+        "!mpirun --allow-run-as-root -np 8 java -cp ./mpi.jar Broadcast"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "tNe1kQLpyqh2"
+      },
+      "source": [
+        "#### Exercise\n",
+        "- Run, using N = from 1 through 8 processes."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "FcckAX8G0Pd-"
+      },
+      "source": [
+        "### Broadcast user input\n",
+        "\n",
+        "The following program will take extra input that will get broadcast to all processes."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "uI7oPCn309N_",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "f41fb72b-287c-45e3-a39e-65bdea3fefce"
+      },
+      "source": [
+        "%%writefile BroadcastUserInput.java\n",
+        "/* Broadcast.java\n",
+        " * ... illustrates the use of MPI's broadcast command \n",
+        " *     to broadcast a value entered from the commandline.\n",
+        " *\n",
+        " * Note: This version uses an IntBuffer of length 1 to store the scalar.\n",
+        " *\n",
+        " * Goal: The master process \"reads\" an input value from the commandline\n",
+        " *        and broadcasts it to all the other processes.\n",
+        " *       Each process outputs its value before and after\n",
+        " *        the broadcast.\n",
+        " *\n",
+        " * Original C version by Hannah Sonsalla, Macalester College 2017,\n",
+        " * Java version by Joel Adams, Calvin University, November 2019.\n",
+        " *\n",
+        " * Usage: mpirun -np 4 java ./BroadcastUserInput <integer>\n",
+        " *\n",
+        " * Exercise:\n",
+        " * - Compile and run several times, varying the number of \n",
+        " *    MPI processes and input value.\n",
+        " * - Explain behavior you observe.\n",
+        " */\n",
+        "\n",
+        "import java.nio.IntBuffer;\n",
+        "import mpi.*;\n",
+        "\n",
+        "public class BroadcastUserInput {\n",
+        "\n",
+        " public static void main(String [] args) throws MPIException {\n",
+        "    MPI.Init(args);\n",
+        "\n",
+        "    Comm comm         = MPI.COMM_WORLD;\n",
+        "    int id            = comm.getRank();\n",
+        "    int numProcesses  = comm.getSize();\n",
+        "    String hostName   = MPI.getProcessorName();\n",
+        "\n",
+        "    IntBuffer answerBuf = MPI.newIntBuffer(1); // allocate buffer\n",
+        "\n",
+        "    if (id == MASTER) {\n",
+        "        getInput(args, answerBuf);             // MASTER: fill buffer\n",
+        "    }\n",
+        "\n",
+        "    String beforeMsg = \"BEFORE the broadcast, the answer of process \" + id\n",
+        "                       + \" on host \" + hostName \n",
+        "                       + \" is \" + answerBuf.get(0) + \"\\n\";\n",
+        "    System.out.print(beforeMsg);               // all: output 'before' values\n",
+        "\n",
+        "    comm.bcast(answerBuf, 1, MPI.INT, 0);      // all: participate in broadcast\n",
+        "\n",
+        "    printSeparator(\"----\", id);\n",
+        "\n",
+        "    String afterMsg = \"AFTER the broadcast, the answer of process \" + id\n",
+        "                       + \" on host \" + hostName \n",
+        "                       + \" is: \" + answerBuf.get(0) + \"\\n\";\n",
+        "    System.out.print(afterMsg);                // all: output 'after' values\n",
+        "\n",
+        "    MPI.Finalize();\n",
+        "  }\n",
+        "\n",
+        "  /* utility to hide details of having the master read an int value\n",
+        "   *  from the commandline (can be adapted to read from anywhere else).\n",
+        "   *\n",
+        "   * @param: args, a String array containing the commandline arguments.\n",
+        "   * @param: buf, an IntBuffer in which to the input value is to be stored.\n",
+        "   *\n",
+        "   * PRE: args[0] contains an integer input value (as a String).\n",
+        "   * POST: buf contains the integer from args[0], or else a default value.\n",
+        "   */\n",
+        "   private static void getInput(String [] args, IntBuffer buf) {\n",
+        "        int result = 0;\n",
+        "        if (args.length >= 1) {\n",
+        "            result = Integer.parseInt( args[0] );\n",
+        "        } else {\n",
+        "            System.err.println(\"\\nUsage: mpirun -np <N> java BroadcastUserInput <integer>\\n\");\n",
+        "        }\n",
+        "        buf.put(result);\n",
+        "    } \n",
+        "\n",
+        "  /* utility to print a separator between the 'before' and 'after' parts.\n",
+        "   * @param: separator, a String.\n",
+        "   * @param: id, the rank of this MPI process.\n",
+        "   * POST: separator has been printed to System.out.\n",
+        "   */\n",
+        "  public static void printSeparator(String separator, int id) throws MPIException {\n",
+        "     MPI.COMM_WORLD.barrier();\n",
+        "     if (id == MASTER) { System.out.println(separator); }\n",
+        "     MPI.COMM_WORLD.barrier();\n",
+        "  }\n",
+        "\n",
+        "\n",
+        "  private static final int MASTER = 0;\n",
+        "}\n"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "wUUqC5t11qJW"
+      },
+      "source": [
+        "![warning sign](https://drive.google.com/uc?id=1SEqDBTBSKwNVXzn-zueWa7fBCm5b1_MB)\n",
+        "**Warning** This program is unlike any of the others and takes in a second argument, as shown below. "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "kzeQF4rB1aa3",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "d21b6018-a855-4a0d-81e8-9ff1897f3408"
+      },
+      "source": [
+        "!javac -cp ./mpi.jar BroadcastUserInput.java \n",
+        "!mpirun --allow-run-as-root -np 4 java -cp ./mpi.jar BroadcastUserInput 6222021"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "ocfu_ZYw3QCz"
+      },
+      "source": [
+        "#### Exercise\n",
+        "- Run, using N = from 1 through 8 processes, with an integer of your choosing."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "0gcBP4q93eCj"
+      },
+      "source": [
+        "### Broadcast a list\n",
+        "\n",
+        "This is just one more example to show that other data structures can also be broadcast from the master to all worker processes."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "d8k_sECN3xCv",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "ab68977a-a73e-458e-eb7b-992e3782e1a6"
+      },
+      "source": [
+        "%%writefile BroadcastArray.java\n",
+        "/* BroadcastArray.java\n",
+        " * ... illustrates the use of MPI's broadcast command with multiple values.\n",
+        " *\n",
+        " * Note: This version uses an array to store the values.\n",
+        " *\n",
+        " * Goal: The master process fills an array with values\n",
+        " *        and broadcasts it to all the other processes.\n",
+        " *       Each process outputs its array before and after\n",
+        " *        the broadcast.\n",
+        " *\n",
+        " * Joel Adams, Calvin University, November 2019,\n",
+        " *\n",
+        " * Usage: mpirun -np 4 java ./Broadcast2\n",
+        " *\n",
+        " * Exercise:\n",
+        " * - Compile, then run several times,\n",
+        " *     using 2, 4, and 8 processes\n",
+        " * - Use source code to trace execution and output\n",
+        " * - Explain behavior/effect of MPI_Bcast().\n",
+        " */\n",
+        "\n",
+        "import mpi.*;\n",
+        "\n",
+        "public class BroadcastArray {\n",
+        "\n",
+        " public static void main(String [] args) throws MPIException {\n",
+        "    MPI.Init(args);\n",
+        "\n",
+        "    Comm comm         = MPI.COMM_WORLD;\n",
+        "    int id            = comm.getRank();\n",
+        "\n",
+        "    int [] array = new int[ARRAY_SIZE];            // all: allocate array \n",
+        "\n",
+        "    if ( id == MASTER ) {                          // MASTER: fill its array\n",
+        "        fill(array);\n",
+        "    }\n",
+        "\n",
+        "    print(\"BEFORE\", id, array);                    // all: print buffers before\n",
+        "\n",
+        "    printSeparator(\"----\", id, comm);\n",
+        "\n",
+        "    comm.bcast(array, array.length, MPI.INT, 0);   // all: participate in broadcast\n",
+        "\n",
+        "    print(\"AFTER\", id, array);                     // all: print buffers after\n",
+        "\n",
+        "    MPI.Finalize();\n",
+        "  }\n",
+        "\n",
+        "\n",
+        "  /* utility to fill an array with some values.\n",
+        "   * @param: a, an int array.\n",
+        "   * POST: a has been filled with int values.\n",
+        "   */\n",
+        "  private static void fill(int [] a) {\n",
+        "     for (int i = 0; i < a.length; ++i) {\n",
+        "         a[i] = i + 11;\n",
+        "     }\n",
+        "  }\n",
+        "\n",
+        "  /* utility to print a buffer with descriptive labels.\n",
+        "   * @param: label, a String.\n",
+        "   * @param: id, this process's MPI rank.\n",
+        "   * @param, a, an int array.\n",
+        "   * POST: label, id, and a have been displayed via System.out.\n",
+        "   */\n",
+        "  private static void print(String label, int id, int [] a) {\n",
+        "    String msg = label + \" the broadcast, process \" + id\n",
+        "                       + \"'s array contains:\";\n",
+        "    for (int i = 0; i < a.length; ++i) {\n",
+        "      msg += (\" \" + a[i]);\n",
+        "    }\n",
+        "    msg += \"\\n\";\n",
+        "    System.out.print(msg); \n",
+        "  }\n",
+        " \n",
+        "  /* utility to print a separator string between the 'before' and 'after' parts.\n",
+        "   * @param: separator, a String.\n",
+        "   * @param: id, the rank of this MPI process.\n",
+        "   * @param: comm, the Communicator for the processes involved.\n",
+        "   * POST: the master has printed the separator to System.out.\n",
+        "   */\n",
+        "  public static void printSeparator(String separator, int id, Comm comm) \n",
+        "                                      throws MPIException {\n",
+        "     comm.barrier();\n",
+        "     if (id == MASTER) { System.out.println(separator); }\n",
+        "     comm.barrier();\n",
+        "  }\n",
+        "\n",
+        "  private static final int MASTER = 0;\n",
+        "  private static final int ARRAY_SIZE = 8;\n",
+        "}\n"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "vSGPEJ244FdZ",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "95b0594a-3843-4c43-93ff-b478a55f8f83"
+      },
+      "source": [
+        "!javac -cp ./mpi.jar BroadcastArray.java \n",
+        "!mpirun --allow-run-as-root -np 4 java -cp ./mpi.jar BroadcastArray"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "IGWlHIPh4t08"
+      },
+      "source": [
+        "#### Exercise\n",
+        "- Run, using N = from 1 through 8 processes.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "ogLec1ig6HZj"
+      },
+      "source": [
+        "# Collective Communication: reduction pattern\n",
+        "\n",
+        "There are often cases when every process needs to complete a partial result of an overall computation. For example if you want to process a large set of numbers by summing them together into one value (i.e. *reduce* a set of numbers into one value, its sum), you could do this faster by having each process compute a partial sum, then have all the processes communicate to add each of their partial sums together.\n",
+        "\n",
+        "This is so common in parallel processing that there is a special collective communication function called **reduce** that does just this."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "cwiw83d44_gR"
+      },
+      "source": [
+        "## Collective Communication: reduce function\n",
+        "\n",
+        "The type of reduction of many values down to one can be done with different types of operators on the set of values computed by each process.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "PrwM90WO6jKv"
+      },
+      "source": [
+        "### Reduce all values using sum and max\n",
+        "In this example, every process computes the square of (id+1). Then all those values are summed together and also the maximum function is applied."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "0jPJPMgE5U_t",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "8f7cfa88-18a7-48ae-ff61-409fea63caaa"
+      },
+      "source": [
+        "%%writefile Reduction.java\n",
+        "/* Reduction.java\n",
+        " * ... illustrates how to use the reduction pattern \n",
+        " *     (which combines distributed values in O(lg(P)) time)\n",
+        " *      using OpenMPI's Java interface.\n",
+        " *\n",
+        " * Joel Adams, Calvin University, November 2019.\n",
+        " *\n",
+        " * Usage: mpirun -np 4 java ./Reduction\n",
+        " *\n",
+        " * Exercise:\n",
+        " * - Compile and run, varying N = 1, 2, 3, 4, 6, 8, 10.\n",
+        " * - Explain behavior of the reduce operation.\n",
+        " */\n",
+        "\n",
+        "import mpi.*;\n",
+        "import java.nio.IntBuffer;\n",
+        "\n",
+        "public class Reduction {\n",
+        "\n",
+        " public static void main(String [] args) throws MPIException {\n",
+        "    MPI.Init(args);\n",
+        "\n",
+        "    Comm comm        = MPI.COMM_WORLD;\n",
+        "    int id           = comm.getRank();\n",
+        "    int numProcesses = comm.getSize();\n",
+        "\n",
+        "    int square       = (id+1) * (id+1);\n",
+        "    IntBuffer squareBuffer = MPI.newIntBuffer(BUFFER_SIZE);\n",
+        "    squareBuffer.put(square);\n",
+        "\n",
+        "    IntBuffer sumSquaresBuffer = MPI.newIntBuffer(BUFFER_SIZE);\n",
+        "    comm.reduce(squareBuffer, sumSquaresBuffer, BUFFER_SIZE,\n",
+        "                 MPI.INT, MPI.SUM, MASTER);\n",
+        "\n",
+        "    IntBuffer maxBuffer = MPI.newIntBuffer(BUFFER_SIZE);\n",
+        "    comm.reduce(squareBuffer, maxBuffer, BUFFER_SIZE,\n",
+        "                 MPI.INT, MPI.MAX, MASTER);\n",
+        "\n",
+        "    if ( id == MASTER) {\n",
+        "        String squareMsg = \"\\nThe sum of the squares from 1 to \"\n",
+        "                            + numProcesses + \" is \" \n",
+        "                            + sumSquaresBuffer.get(0) + \"\\n\\n\";\n",
+        "        String maxMsg    = \"The max of the squares from 1 to \"\n",
+        "                            + numProcesses + \" is \" \n",
+        "                            + maxBuffer.get(0) + \"\\n\\n\";\n",
+        "        System.out.print(squareMsg);\n",
+        "        System.out.print(maxMsg);\n",
+        "    }\n",
+        "\n",
+        "    MPI.Finalize();\n",
+        "  }\n",
+        "\n",
+        "  private static int BUFFER_SIZE = 1;\n",
+        "  private static int MASTER      = 0;\n",
+        "}\n"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "8xAazDP17GJJ",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "29e2feff-a2ae-4950-e6bd-ed8d35378732"
+      },
+      "source": [
+        "!javac -cp ./mpi.jar Reduction.java\n",
+        "!mpirun --allow-run-as-root -np 4 java -cp ./mpi.jar Reduction"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "YRLLMm9j7iOA"
+      },
+      "source": [
+        "#### Exercises\n",
+        "- Run, using N = from 1 through 8 processes.\n",
+        "- Try replacing MPI.MAX with MPI.MIN(minimum) and/or replacing MPI.SUM with MPI.PROD (product). Then save and run the code again.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "JnO-S8V37tpD"
+      },
+      "source": [
+        "### Reduction on a list of values\n",
+        "\n",
+        "We can try reduction with lists of values, but the behavior matches Python semantics regarding lists. Note this in the following example. Then note how you can change the semantics in the exercises.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "gsAow5Ds8DAv",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "36562141-fb8e-4081-9456-bb3a42987fff"
+      },
+      "source": [
+        "%%writefile Reduction2.java\n",
+        "/* Reduction2.java\n",
+        " * ... illustrates the reduction pattern on multiple values,\n",
+        " *      using buffers in OpenMPI's Java interface.\n",
+        " *\n",
+        " * Joel Adams, Calvin University, November 2019.\n",
+        " *\n",
+        " * Usage: mpirun -np 4 java ./Reduction2\n",
+        " *\n",
+        " * Exercise:\n",
+        " * - Compile, then run with N = 1, 2, 3, 4, \n",
+        " *     comparing output to source code.\n",
+        " * - Explain behavior of reduce() in terms of\n",
+        " *     srcBuf and destBuf.\n",
+        " */\n",
+        "\n",
+        "import mpi.*;\n",
+        "import java.nio.IntBuffer;\n",
+        "\n",
+        "public class Reduction2 {\n",
+        "\n",
+        " public static void main(String [] args) throws MPIException {\n",
+        "    MPI.Init(args);\n",
+        "\n",
+        "    Comm comm        = MPI.COMM_WORLD;\n",
+        "    int id           = comm.getRank();\n",
+        "    int numProcesses = comm.getSize();\n",
+        "\n",
+        "    IntBuffer srcBuf = MPI.newIntBuffer(BUFFER_SIZE);\n",
+        "    IntBuffer destBuf = MPI.newIntBuffer(BUFFER_SIZE);\n",
+        "\n",
+        "    if (id == MASTER) {\n",
+        "        System.out.print(\"\\nBefore reduction: \");\n",
+        "        printBuf(id, \"destBuf\", destBuf); \n",
+        "    }\n",
+        "\n",
+        "    for (int i = 0; i < BUFFER_SIZE; ++i) {\n",
+        "        srcBuf.put(i, id * i);\n",
+        "    }\n",
+        "\n",
+        "    printSeparator(\"\", id);\n",
+        "    printBuf(id, \"srcBuf\", srcBuf);\n",
+        "    printSeparator(\"----\", id);\n",
+        "\n",
+        "    comm.reduce(srcBuf, destBuf, BUFFER_SIZE,\n",
+        "                 MPI.INT, MPI.SUM, MASTER);\n",
+        "\n",
+        "    if ( id == MASTER) {\n",
+        "        System.out.print(\"After reduction: \");\n",
+        "        printBuf(id, \"destBuf\", destBuf);\n",
+        "        System.out.println();\n",
+        "    }\n",
+        "\n",
+        "    MPI.Finalize();\n",
+        "  }\n",
+        "\n",
+        "  /* utility to display the contents of an IntBuffer.\n",
+        "   * @param: id, the int MPI rank of this process.\n",
+        "   * @param: bufName, a String that is the name of the buffer.\n",
+        "   * @param: buf, the IntBuffer.\n",
+        "   * @param: size, the size of buf.\n",
+        "   */\n",
+        "  private static void printBuf(int id, String bufName, IntBuffer buf) {\n",
+        "      String msg = \"Process \" + id + \", \" + bufName + \": [\";\n",
+        "      int size = buf.capacity();\n",
+        "      int sizeLessOne = size - 1;\n",
+        "      for (int i = 0; i < size; ++i) {\n",
+        "         msg += buf.get(i);\n",
+        "         if (i < sizeLessOne ) {\n",
+        "             msg += \",\";\n",
+        "         }\n",
+        "      }\n",
+        "      msg += \"]\\n\";\n",
+        "      System.out.print(msg);\n",
+        "  }\n",
+        "\n",
+        "  /* utility to print a separator between before and after sections.\n",
+        "   * @param: separator, a String.\n",
+        "   * @param: id, the MPI rank of this process. \n",
+        "   * POST: separator has been printed by the master process.\n",
+        "   */\n",
+        "  private static void printSeparator(String separator, int id) throws MPIException {\n",
+        "     MPI.COMM_WORLD.barrier();\n",
+        "     if (id == MASTER) { System.out.println(separator); }\n",
+        "     MPI.COMM_WORLD.barrier();\n",
+        "  }\n",
+        "\n",
+        "  private static int BUFFER_SIZE = 5;\n",
+        "  private static int MASTER      = 0;\n",
+        "}\n"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "Uow-rYeS8rxc",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "e5d72f2e-6eef-4ffc-a31d-062f91db57bf"
+      },
+      "source": [
+        "!javac -cp ./mpi.jar Reduction2.java \n",
+        "!mpirun --allow-run-as-root -np 4 java -cp ./mpi.jar Reduction2"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "P74yRNds9SBx"
+      },
+      "source": [
+        "#### Exercises\n",
+        "- Run, using N = from 1 through 4 processes.\n",
+        "- Uncomment the two lines of runnable code that are commented in the main() function. Observe the new results and explain why the MPI.SUM (using the + operator underneath) behaves the way it does on lists, and what the new function called sumListByElements is doing instead.\n",
+        "\n",
+        "![Important symbol](https://drive.google.com/uc?id=1AWRLAqeaqi7SG7PHyOVywZRuMDK9Z2_s) **Note:** There are two ways in Python that you might want to sum a set of lists from each process: 1) concatenating the elements together, or 2) summing the element at each location from each process and placing the sum in that location in a new list. In the latter case, the new list is the same length as the original lists on each process.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "HYFc1mVp-e2r"
+      },
+      "source": [
+        "# Collective Communication: scatter and gather pattern\n",
+        "\n",
+        "There are often cases when each process can work on some portion of a larger data structure. This can be carried out by having the master process maintain the larger structure and send parts to each of the worker processes, keeping part of the structure on the master. Each process then works on their portion of the data, and then the master can get the completed portions back.\n",
+        "\n",
+        "This is so common in message passing parallel processing that there are two special collective communication functions called **scatter** and **gather** that handle this.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "gL2CQgIo-xTd"
+      },
+      "source": [
+        "## Collective Communication: scatter and gather lists\n",
+        "\n",
+        "When several processes need to work on portions of a data structure, such as a list of lists or a 1-d or 2-d array, at various points in a program, a way to do this is to have one node, usually the master, divide the data structure and send portions to each of the other processes, often keeping one portion for itself. Each process then works on that portion of the data, and then the master can get the completed portions back. This type of coordination is so common that MPI has special patterns for it called **scatter** and **gather**.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "1g5HzFU1--zY"
+      },
+      "source": [
+        "### Scatter Lists\n",
+        "The following diagrams illustrate how scatter using python list structures works. The master contains a list of lists and all processes participate in the scatter:\n",
+        "\n",
+        "![scatter lists diagram](https://drive.google.com/uc?id=1QDRW2JeAa_TelKxZTphCPF393Bxn_BbL)\n",
+        "\n",
+        "After the scatter is completed, each process has one of the smaller lists to work on, like this:\n",
+        "\n",
+        "![after scatter lists diagram](https://drive.google.com/uc?id=1xA2NRtm1k4_g16tJTWBFCVArKLfIEurc)\n",
+        "\n",
+        "In this next code example, some small lists are created in a list whose length is as long as the number of processes.\n",
+        "\n",
+        "![Important symbol](https://drive.google.com/uc?id=1AWRLAqeaqi7SG7PHyOVywZRuMDK9Z2_s) **Note:** In the code below, note how all processes must call the scatter function."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "FI6C7UH7AiMV",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "ccdcdc95-72d1-4794-83f7-c92f2917cadb"
+      },
+      "source": [
+        "%%writefile Scatter.java\n",
+        "/* Scatter.java\n",
+        " * ... illustrates the basic scatter pattern \n",
+        " *      using buffers in OpenMPI's Java interface.\n",
+        " *\n",
+        " * Note: If the number of values being scattered is not\n",
+        " *       evenly divisible by the number of processes,\n",
+        " *       use scatterv() instead of scatter.\n",
+        " *\n",
+        " * Joel Adams, Calvin University, November 2019.\n",
+        " *\n",
+        " * Usage: mpirun -np 4 java ./Scatter\n",
+        " *\n",
+        " * Exercise:\n",
+        " * - Compile, then run with N = 1, 2, 4, 8. \n",
+        " * - Trace execution through source code. \n",
+        " * - Explain behavior/effect of scatter. \n",
+        " * - What if BUFFER_SIZE is not evenly divisible by N?\n",
+        " */\n",
+        "\n",
+        "import mpi.*;\n",
+        "import java.nio.IntBuffer;\n",
+        "\n",
+        "public class Scatter {\n",
+        "\n",
+        " public static void main(String [] args) throws MPIException {\n",
+        "    MPI.Init(args);\n",
+        "\n",
+        "    Comm comm         = MPI.COMM_WORLD;\n",
+        "    int id            = comm.getRank();\n",
+        "    int numProcesses  = comm.getSize();\n",
+        "\n",
+        "    if (numProcesses > BUFFER_SIZE) {\n",
+        "        if (id == MASTER) {\n",
+        "            System.out.println(\"\\nPlease run this program with N <= 8 processes\\n\");\n",
+        "        }\n",
+        "        MPI.Finalize();\n",
+        "        System.exit(0);\n",
+        "    }\n",
+        "    IntBuffer sendBuf = null;\n",
+        "    IntBuffer recvBuf = null;\n",
+        "\n",
+        "    if (id == MASTER) {\n",
+        "        sendBuf = MPI.newIntBuffer(BUFFER_SIZE);\n",
+        "        for (int i = 0; i < BUFFER_SIZE; ++i) {\n",
+        "           sendBuf.put(i, (i+1) * 11);\n",
+        "        }\n",
+        "        System.out.print(\"\\nBefore scatter: \");\n",
+        "        printBuf(id, \"sendBuf\", sendBuf);\n",
+        "    }\n",
+        " \n",
+        "    int numSent = BUFFER_SIZE / numProcesses;\n",
+        "       \n",
+        "    comm.barrier();                    // see comment on next barrier\n",
+        "\n",
+        "    recvBuf = MPI.newIntBuffer(numSent);\n",
+        "    printBuf(id, \"recvBuf\", recvBuf);\n",
+        "\n",
+        "    printSeparator(\"----\", id);\n",
+        "\n",
+        "    comm.scatter(sendBuf, numSent, MPI.INT, \n",
+        "                  recvBuf, numSent, MPI.INT, MASTER); \n",
+        "\n",
+        "    if (id == MASTER) {\n",
+        "        System.out.print(\"After scatter:\\n\");\n",
+        "    }\n",
+        "    comm.barrier();                    // all of these barriers are here\n",
+        "    printBuf(id, \"recvBuf\", recvBuf);  //  just to make the output easier\n",
+        "    comm.barrier();                    //  to read; no effect on correctness\n",
+        "    if (id == MASTER) {\n",
+        "        System.out.println();\n",
+        "    }\n",
+        "\n",
+        "    MPI.Finalize();\n",
+        "  }\n",
+        "\n",
+        "  /* utility to display the contents of an IntBuffer.\n",
+        "   * @param: id, the int MPI rank of this process.\n",
+        "   * @param: bufName, a String that is the name of the buffer.\n",
+        "   * @param: buf, the IntBuffer.\n",
+        "   * @param: size, the size of buf.\n",
+        "   */\n",
+        "  private static void printBuf(int id, String bufName, IntBuffer buf) {\n",
+        "      String msg = \"Process \" + id + \", \" + bufName + \": [\";\n",
+        "      int size = buf.capacity();\n",
+        "      int sizeLessOne = size - 1;\n",
+        "      for (int i = 0; i < size; ++i) {\n",
+        "         msg += buf.get(i);\n",
+        "         if (i < sizeLessOne ) {\n",
+        "             msg += \",\";\n",
+        "         }\n",
+        "      }\n",
+        "      msg += \"]\\n\";\n",
+        "      System.out.print(msg);\n",
+        "  }\n",
+        "\n",
+        "  /* utility to print a separator between before and after sections.\n",
+        "   * @param: separator, a String.\n",
+        "   * @param: id, the MPI rank of this process. \n",
+        "   * POST: separator has been printed by the master process.\n",
+        "   */\n",
+        "  private static void printSeparator(String separator, int id) throws MPIException {\n",
+        "     MPI.COMM_WORLD.barrier();\n",
+        "     if (id == MASTER) { System.out.print(separator + \"\\n\"); }\n",
+        "     MPI.COMM_WORLD.barrier();\n",
+        "  }\n",
+        "\n",
+        "  private static int BUFFER_SIZE = 8;\n",
+        "  private static int MASTER      = 0;\n",
+        "}\n"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "qgt8fHPaA0CH",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "e813b0ea-23e7-4054-bc77-625240a77893"
+      },
+      "source": [
+        "!javac -cp ./mpi.jar Scatter.java \n",
+        "!mpirun --allow-run-as-root -np 4 java -cp ./mpi.jar Scatter"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "H9EYqJldBRS-"
+      },
+      "source": [
+        "#### Exercises\n",
+        "- Run, using N = from 2 through 8 processes.\n",
+        "- If you want to study the code, explain to yourself what genListofLists does in the code below.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "tIw9YI6GB5go"
+      },
+      "source": [
+        "### Gather Lists\n",
+        "Once several processes have their own lists of data, those lists can also be gathered back together into a list of lists, usually in the master process. All processes participate in a gather, like this:\n",
+        "\n",
+        "![before gather diagram](https://drive.google.com/uc?id=1OWHNMKCEKsGpExJCO6l5czW9QFyMZiT6)\n",
+        "\n",
+        "The gather creates a list of lists in the master, like this:\n",
+        "\n",
+        "![after gather diagram](https://drive.google.com/uc?id=1W9lky1LY0L0K6iyA00jsNV4hAnmmbvP2)\n",
+        "\n",
+        "In this example, each process creates some very small lists. Then a gather is used to create a list of lists on the master process.\n",
+        "\n",
+        "![Important symbol](https://drive.google.com/uc?id=1AWRLAqeaqi7SG7PHyOVywZRuMDK9Z2_s) **Note:** In the code below, note how all processes must call the gather function.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "GPk2IBX_C46Z",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "8ab9b72a-c830-4f56-b587-1c14e3d0910d"
+      },
+      "source": [
+        "%%writefile Gather.java\n",
+        "/* Gather.java\n",
+        " * ... illustrates the basic gather pattern \n",
+        " *      using buffers in OpenMPI's Java interface.\n",
+        " *\n",
+        " * Note: If the number of values being gathered is not\n",
+        " *       evenly divisible by the number of processes,\n",
+        " *       use gatherv() instead of gather.\n",
+        " *\n",
+        " * Joel Adams, Calvin University, November 2019.\n",
+        " *\n",
+        " * Usage: mpirun -np 4 java ./Gather\n",
+        " *\n",
+        " * Exercise:\n",
+        " * - Compile, then run with N = 1, 2, 3, 4, 5. \n",
+        " * - Trace execution through source code. \n",
+        " * - Explain behavior/effect of gather. \n",
+        " */\n",
+        "\n",
+        "import mpi.*;\n",
+        "import java.nio.IntBuffer;\n",
+        "\n",
+        "public class Gather {\n",
+        "\n",
+        " public static void main(String [] args) throws MPIException {\n",
+        "    MPI.Init(args);\n",
+        "\n",
+        "    Comm comm         = MPI.COMM_WORLD;\n",
+        "    int id            = comm.getRank();\n",
+        "    int numProcesses  = comm.getSize();\n",
+        "\n",
+        "    IntBuffer gatherBuf = null;\n",
+        "\n",
+        "    if (id == MASTER) {\n",
+        "        int valuesToGather = BUFFER_SIZE * numProcesses;\n",
+        "        gatherBuf = MPI.newIntBuffer(valuesToGather);\n",
+        "        System.out.print(\"\\nBefore gather: \");\n",
+        "        printBuf(id, \"gatherBuf\", gatherBuf);\n",
+        "    }\n",
+        " \n",
+        "    IntBuffer computeBuf = MPI.newIntBuffer(BUFFER_SIZE);\n",
+        "    for (int i = 0; i < BUFFER_SIZE; ++i) {\n",
+        "        computeBuf.put(i, id * 10 + i);\n",
+        "    }   \n",
+        "    comm.barrier();                          // These barriers are just here\n",
+        "    printBuf(id, \"computeBuf\", computeBuf);  // to make the output easier to read;\n",
+        "    comm.barrier();                          // no effect on functional correctness\n",
+        "\n",
+        "    printSeparator(\"----\", id);\n",
+        "\n",
+        "    comm.gather(computeBuf, BUFFER_SIZE, MPI.INT, \n",
+        "                  gatherBuf, BUFFER_SIZE, MPI.INT, MASTER); \n",
+        "\n",
+        "    if (id == MASTER) {\n",
+        "        System.out.print(\"After gather: \");\n",
+        "        printBuf(id, \"gatherBuf\", gatherBuf); \n",
+        "        System.out.println();\n",
+        "    }\n",
+        "\n",
+        "    MPI.Finalize();\n",
+        "  }\n",
+        "\n",
+        "  /* utility to display the contents of an IntBuffer.\n",
+        "   * @param: id, the int MPI rank of this process.\n",
+        "   * @param: bufName, a String that is the name of the buffer.\n",
+        "   * @param: buf, the IntBuffer.\n",
+        "   * @param: size, the size of buf.\n",
+        "   */\n",
+        "  private static void printBuf(int id, String bufName, IntBuffer buf) {\n",
+        "      String msg = \"Process \" + id + \", \" + bufName + \": [\";\n",
+        "      int size = buf.capacity();\n",
+        "      int sizeLessOne = size - 1;\n",
+        "      for (int i = 0; i < size; ++i) {\n",
+        "         msg += buf.get(i);\n",
+        "         if (i < sizeLessOne ) {\n",
+        "             msg += \",\";\n",
+        "         }\n",
+        "      }\n",
+        "      msg += \"]\\n\";\n",
+        "      System.out.print(msg);\n",
+        "  }\n",
+        "\n",
+        "  /* utility to print a separator between before and after sections.\n",
+        "   * @param: separator, a String.\n",
+        "   * @param: id, the MPI rank of this process. \n",
+        "   * POST: separator has been printed by the master process.\n",
+        "   */\n",
+        "  private static void printSeparator(String separator, int id) throws MPIException {\n",
+        "     MPI.COMM_WORLD.barrier();\n",
+        "     if (id == MASTER) { System.out.print(separator + \"\\n\"); }\n",
+        "     MPI.COMM_WORLD.barrier();\n",
+        "  }\n",
+        "\n",
+        "  private static int BUFFER_SIZE = 3;\n",
+        "  private static int MASTER      = 0;\n",
+        "}\n"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "UvdQljANDOtE",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "224f73ab-bba2-4b7b-d259-f049541ddef5"
+      },
+      "source": [
+        "!javac -cp ./mpi.jar Gather.java\n",
+        "!mpirun --allow-run-as-root -np 4 java -cp ./mpi.jar Gather"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "mPVwi5W4DpwJ"
+      },
+      "source": [
+        "#### Exercises\n",
+        "- Run, using N = from 2 through 8 processes.\n",
+        "- Try with different values of SMALL_LIST_SIZE, perhaps changing printing of result for readability\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "-eCGJi2hEOC1"
+      },
+      "source": [
+        "## Collective Communication:  scatter and gather arrays\n",
+        "\n",
+        "The mpi4py library of functions has several collective communication functions that are designed to work with arrays created using the python library for numerical analysis computations called *numpy*.\n",
+        "\n",
+        "If you are unfamiliar with using numpy, and want to know more about its features and available methods, you will need to consult another tutorial for that. It should be possible to understand the following scatter, then gather example by observing the results that get printed, even if you are unfamiliar with the functions from numpy that are used to create the 1-D array.\n",
+        "\n",
+        "The numpy library has special data structures called arrays, that are common in other programming languages. A 1-dimensional array of integers can be envisioned very much like a list of integers, where each value in the array is at a particular index. The mpi4py Scatter function, with a capital S, can be used to send portions of a larger array on the master to the workers, like this:\n",
+        "\n",
+        "![alt text](https://drive.google.com/uc?id=1n2YmY12tBrTxtJK6MFpBX9nWmopQGT_s)\n",
+        "\n",
+        "The result of doing this then looks like this, where each process has a portion of the original that they can then work on:\n",
+        "\n",
+        "![alt text](https://drive.google.com/uc?id=19GNbTWWJEOU16wNjwzHon4jpC5fXKj_1)\n",
+        "\n",
+        "The reverse of this process can be done using the Gather function.\n",
+        "\n",
+        "In this example, a 1-D array is created by the master, then scattered, using Scatter (capital S). After each smaller array used by each process is changed, the Gather (capital G) function brings the full array with the changes back into the master.\n",
+        "\n",
+        "![Important symbol](https://drive.google.com/uc?id=1AWRLAqeaqi7SG7PHyOVywZRuMDK9Z2_s) **Note:** In the code below, note how all processes must call the Scatter and Gather functions."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "cO06o4HAFBZR",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "ae2bf754-8b78-4b76-a7ca-799b79ef6794"
+      },
+      "source": [
+        "%%writefile ScatterLoopGather.java\n",
+        "/* ScatterLoopGather.java\n",
+        " * ... uses MPI to scatter a buffer of values into chunks, \n",
+        " *      a loop to process those chunks, and \n",
+        " *      a gather to combine the piecemeal values.\n",
+        " *\n",
+        " * Goal: The master process fills a buffer with values\n",
+        " *        and scatters it to all the other processes.\n",
+        " *       Each process doubles the values in its buffer-chunk.\n",
+        " *       All processes then gather the chunks back to the master.\n",
+        " *\n",
+        " * Joel Adams, Calvin University, November 2019.\n",
+        " *\n",
+        " * Note: This assumes BUFFER_SIZE is evenly divisible by N.\n",
+        " *\n",
+        " * Usage: mpirun -np 4 java ./BroadcastLoopGather\n",
+        " *\n",
+        " * Exercise:\n",
+        " * - Compile, then run, using 1, 2, 4, and 8 processes\n",
+        " * - Use source code to trace execution and output\n",
+        " * - Explain behavior/effect of the scatter and gather.\n",
+        " * - Optional: change BUFFER_SIZE to be another multiple of 8, such as 16\n",
+        " */\n",
+        "\n",
+        "import java.nio.IntBuffer;\n",
+        "import mpi.*;\n",
+        "\n",
+        "public class ScatterLoopGather {\n",
+        "\n",
+        " public static void main(String [] args) throws MPIException {\n",
+        "    MPI.Init(args);\n",
+        "\n",
+        "    Comm comm               = MPI.COMM_WORLD;\n",
+        "    int id                  = comm.getRank();\n",
+        "    int numProcesses        = comm.getSize();\n",
+        "    IntBuffer scatterBuffer = null;\n",
+        "    IntBuffer chunkBuffer   = null;\n",
+        "    IntBuffer gatherBuffer  = null;\n",
+        "\n",
+        "    if ( BUFFER_SIZE % numProcesses != 0 || numProcesses > BUFFER_SIZE ) {\n",
+        "        String errorMsg = \"\\nPlease run this program with -np N where N is\\n\"\n",
+        "                         + \" <= \" + BUFFER_SIZE + \" and divides evenly into \"\n",
+        "                         + BUFFER_SIZE + \"\\n\\n\";\n",
+        "        System.err.println(errorMsg);\n",
+        "        MPI.Finalize();\n",
+        "        System.exit(0);\n",
+        "    }\n",
+        "\n",
+        "    if ( id == MASTER ) { \n",
+        "        scatterBuffer = MPI.newIntBuffer(BUFFER_SIZE);\n",
+        "        fill(scatterBuffer);\n",
+        "        gatherBuffer = MPI.newIntBuffer(BUFFER_SIZE);\n",
+        "    }\n",
+        "\n",
+        "    printBuffers(\"BEFORE the scatter\", id, scatterBuffer, chunkBuffer, gatherBuffer);\n",
+        "\n",
+        "    int chunkSize = BUFFER_SIZE / numProcesses;\n",
+        "    chunkBuffer = MPI.newIntBuffer(chunkSize);\n",
+        "\n",
+        "    comm.scatter(scatterBuffer, chunkSize, MPI.INT, \n",
+        "                  chunkBuffer, chunkSize, MPI.INT, MASTER);\n",
+        "\n",
+        "    printSeparator(\"----\", id);\n",
+        "    printBuffers(\"AFTER the scatter\", id, scatterBuffer, chunkBuffer, gatherBuffer);\n",
+        "\n",
+        "    doubleChunk(chunkBuffer);\n",
+        "\n",
+        "    printSeparator(\"----\", id);\n",
+        "    printBuffers(\"AFTER the doubling\", id, scatterBuffer, chunkBuffer, gatherBuffer);\n",
+        "\n",
+        "    comm.gather(chunkBuffer, chunkSize, MPI.INT, \n",
+        "                 gatherBuffer, chunkSize, MPI.INT, MASTER);\n",
+        "\n",
+        "    printSeparator(\"----\", id);\n",
+        "    printBuffers(\"AFTER the gather:\", id, scatterBuffer, chunkBuffer, gatherBuffer);\n",
+        "\n",
+        "    MPI.Finalize();\n",
+        "  }\n",
+        "\n",
+        "  /* utility to fill a Buffer with some values.\n",
+        "   * @param: buf, an IntBuffer.\n",
+        "   * POST: buf has been filled with int values.\n",
+        "   */\n",
+        "  private static void fill(IntBuffer buf) {\n",
+        "     for (int i = 0; i < buf.capacity(); ++i) {\n",
+        "         buf.put(i, i + 11);\n",
+        "     }\n",
+        "  }\n",
+        "\n",
+        "  /* utility to print a buffer with labels.\n",
+        "   * @param: label, a String.\n",
+        "   * @param: id, an int containing the MPI rank of this process.\n",
+        "   * @param: sBuf, the IntBuffer the master fills and scatters.\n",
+        "   * @param: cBuf, the IntBuffer for storing a process's chunk.\n",
+        "   * @param: gBuf, the IntBuffer for storing the gathered results.\n",
+        "   * POST: The buffers' contents have been printed, with labels.\n",
+        "   */\n",
+        "  private static void printBuffers(String label, int id, \n",
+        "                                    IntBuffer sBuf, IntBuffer cBuf, IntBuffer gBuf) {\n",
+        "    String msg = label + \", process \" + id\n",
+        "                       + \"'s scatterBuffer is: [\";\n",
+        "    if (sBuf != null) {\n",
+        "        for (int i = 0; i < sBuf.capacity(); ++i) {\n",
+        "            msg += sBuf.get(i);\n",
+        "            if (i < sBuf.capacity()-1) msg += \",\";\n",
+        "        }\n",
+        "    }\n",
+        "    msg += \"]\\n\\t\\t\\t\\tchunkBuffer is: [\";\n",
+        "    if (cBuf != null) {\n",
+        "        for (int i = 0; i < cBuf.capacity(); ++i) {\n",
+        "            msg += cBuf.get(i);\n",
+        "            if (i < cBuf.capacity()-1) msg += \",\";\n",
+        "        }\n",
+        "    }\n",
+        "    msg += \"]\\n\\t\\t\\t\\tgatherBuffer is: [\";\n",
+        "    if (gBuf != null) {\n",
+        "        for (int i = 0; i < gBuf.capacity(); ++i) {\n",
+        "            msg += gBuf.get(i);\n",
+        "            if (i < gBuf.capacity()-1) msg += \",\";\n",
+        "        }\n",
+        "    }\n",
+        "    msg += \"]\\n\";\n",
+        "    System.out.print(msg);\n",
+        "  }\n",
+        "\n",
+        "  /* utility to double the values in a chunk of an array.\n",
+        "   * @param: fullBuf, an IntBuffer containing all the values.\n",
+        "   * @param: id, the MPI rank of this process.\n",
+        "   * @param: chunkBuf, an IntBuffer into which we will write our values.\n",
+        "   * PRE: chunkBuf.capacity() == BUFFER_SIZE / numProcesses.\n",
+        "   * POST: chunkBuf contains the doubled values of this process's chunk\n",
+        "   *        of fullBuf.\n",
+        "   */\n",
+        "  private static void doubleChunk(IntBuffer chunkBuf) {\n",
+        "      for (int i = 0; i < chunkBuf.capacity(); ++i) {\n",
+        "          int value = chunkBuf.get(i);\n",
+        "          chunkBuf.put(i, value * 2);\n",
+        "      }\n",
+        "  }\n",
+        "\n",
+        "  /* utility to print a separator string between the 'before' and 'after' parts.\n",
+        "   * @param: separator, a String.\n",
+        "   * @param: id, the rank of this MPI process.\n",
+        "   * POST: the master has printed the separator to System.out.\n",
+        "   */\n",
+        "  public static void printSeparator(String separator, int id) throws MPIException {\n",
+        "     MPI.COMM_WORLD.barrier();\n",
+        "     if (id == MASTER) { System.out.println(separator); }\n",
+        "     MPI.COMM_WORLD.barrier();\n",
+        "  }\n",
+        "\n",
+        "  private static final int MASTER      = 0;\n",
+        "  private static final int BUFFER_SIZE = 8;\n",
+        "}\n"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "uMIeHGkDFQ1V",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "838f8bb0-6b52-4139-dfc8-a5c921f2bdce"
+      },
+      "source": [
+        "!javac -cp ./mpi.jar ScatterLoopGather.java \n",
+        "!mpirun --allow-run-as-root -np 4 java -cp ./mpi.jar ScatterLoopGather"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "qKhQXI7oFRMf"
+      },
+      "source": [
+        "#### Exercises\n",
+        "- Run, using N = from 2 through 8 processes.\n",
+        "- If you want to study the numpy part of the code, look up the numpy function linspace used in genArray().\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "dnjHsPScGpEP"
+      },
+      "source": [
+        "# When amount of work varies: balancing the load\n",
+        "\n",
+        "There are algorithms where the master is used to assign tasks to workers by sending them data and receiving results back as each worker completes a task (or after the worker completes all of its tasks). In many of these cases, the computation time needed by each worker process for each of its tasks can vary somewhat dramatically. This situation is where **dynamic load balancing** can be helpful.\n",
+        "\n",
+        "In this example we combine the master-worker pattern with message passing. The master has many tasks that need to be completed. The master starts by sending some data needed to complete a task to each worker process. Then the master loops and waits to hear back from each worker by receiving a message from any of them. When the master receives a message from a worker, it sends that worker more data for its next task, unless there are no more tasks to complete, in which case it sends a special message to the worker to stop running.\n",
+        "\n",
+        "In this simple example, each worker is sent the number of seconds it should 'sleep', which can vary from 1 to 8. This illustrates varying sizes of workloads. Because of the code's simplicity, the number of tasks each worker does doesn't vary by much. In some real examples, the time for one task my be quite different than the time for another, which could have a different outcome, in which some workers were able to complete more tasks as others were doing long ones.\n",
+        "\n",
+        "This approach can sometimes be an improvement on the assignment of an equal number of tasks to all processes.\n",
+        "\n",
+        "Note in this case how the master, whose id is 0, handles the assignment of tasks, while the workers simply do what they are sent until they are told to stop."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "ow-7CfeCHY3n",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "c54015c3-75b3-43b9-9b15-2bac38c8102e"
+      },
+      "source": [
+        "%%writefile DynamicLoadBalance.java\n",
+        "/* DynamicLoadBalance.java\n",
+        " * ... illustrates how to use the dynamic load balancing pattern \n",
+        " *     using OpenMPI's Java interface.\n",
+        " * This code was based on the dynamicLoadBalance.py script,\n",
+        " * that was originally written by Libby Shoop (Macalester College)\n",
+        " * \n",
+        " * Ruth Kurniawati, Westfield State University, June 2021.\n",
+        " *\n",
+        " * Usage: mpirun -np 4 java ./DynamicLoadBalance\n",
+        " *\n",
+        " * Exercise:\n",
+        " * - Compile and run, varying N = 4, 8.\n",
+        " * - Explain behavior of the dynamic load balancing of the available work\n",
+        " */\n",
+        "\n",
+        "import java.util.Arrays;\n",
+        "import java.util.Random;\n",
+        "\n",
+        "import mpi.*;\n",
+        "import java.nio.IntBuffer;\n",
+        "\n",
+        "public class DynamicLoadBalance {\n",
+        "    public static final int MASTER = 0;\n",
+        "\n",
+        "    // tags that can be applied to messages\n",
+        "    public static final int WORKTAG = 1;\n",
+        "    public static final int DIETAG = 2;\n",
+        "\n",
+        "    public static void main(String [] args) throws MPIException {\n",
+        "       MPI.Init(args);\n",
+        "   \n",
+        "       int id           = MPI.COMM_WORLD.getRank();\n",
+        "       int numProcesses = MPI.COMM_WORLD.getSize();\n",
+        "       //String hostName  = MPI.getProcessorName();\n",
+        "   \n",
+        "       if (id == MASTER) {\n",
+        "            // create an arbitrary array of numbers for how long each\n",
+        "            // worker task will 'work', by sleeping that amount of seconds\n",
+        "            int numTasks = (numProcesses-1) * 4; // avg 4 tasks per worker process\n",
+        "            int[] workTimes = genTasks(numTasks);\n",
+        "            System.out.println(\"master created \" + workTimes.length + \" values for sleep times:\" + Arrays.toString(workTimes));\n",
+        "            handOutWork(MPI.COMM_WORLD, workTimes, numProcesses);\n",
+        "            \n",
+        "       } else {\n",
+        "            worker(MPI.COMM_WORLD);\n",
+        "       }   \n",
+        "       MPI.Finalize();\n",
+        "    }\n",
+        "\n",
+        "    private static int[] genTasks(int numTasks) {\n",
+        "        int[] tasks = new int[numTasks];\n",
+        "        Random r = new Random(1000); // use the same seed\n",
+        "        for(int i = 0; i < numTasks; i++) {\n",
+        "            tasks[i] = r.nextInt(8) + 1;\n",
+        "        }\n",
+        "        return tasks;\n",
+        "    }\n",
+        "\n",
+        "    private static void worker(Comm comm) throws MPIException {\n",
+        "        // keep receiving messages and do work, unless tagged to 'die'\n",
+        "        IntBuffer buf = MPI.newIntBuffer(1);\n",
+        "        while(true) {\n",
+        "            Status stat = comm.recv(buf, 1, MPI.INT, 0, MPI.ANY_TAG);\n",
+        "            int waitTime = buf.get(0);\n",
+        "            System.out.println(\"worker \"+comm.getRank()+\" got \"+ waitTime);\n",
+        "            if (stat.getTag() == DIETAG) {\n",
+        "                System.out.println(\"worker \"+comm.getRank()+\" dying\");\n",
+        "                return;\n",
+        "            }\n",
+        "            // simulate work by sleeping\n",
+        "            try {\n",
+        "                Thread.sleep(1000*waitTime); // sleep for waitTime seconds\n",
+        "            } catch (InterruptedException e) {\n",
+        "                e.printStackTrace();\n",
+        "            } \n",
+        "\n",
+        "            // indicate done with work by sending to Master\n",
+        "            //System.out.println(\"worker \"+comm.getRank()+\" completed work!\");\n",
+        "            buf.put(0, waitTime);\n",
+        "            comm.send(buf, 1, MPI.INT, 0, WORKTAG);\n",
+        "        }\n",
+        "    }\n",
+        "\n",
+        "    private static void handOutWork(Comm comm, int[] workTimes, int numProcesses) throws MPIException {\n",
+        "        int totalWork = workTimes.length;\n",
+        "        int workCount = 0, recvCount = 0;\n",
+        "        System.out.println(\"master sending first tasks\");\n",
+        "        IntBuffer sendBuf = MPI.newIntBuffer(1);\n",
+        "         \n",
+        "        for(int id = 1; id < numProcesses; id++) {\n",
+        "            int work = workTimes[workCount++];\n",
+        "            sendBuf.put(0, work);\n",
+        "            comm.send(sendBuf, 1, MPI.INT, id, WORKTAG);\n",
+        "            System.out.println(\"master sent \"+ work +\" to \"+id);\n",
+        "        }\n",
+        "\n",
+        "        // while there is still work,\n",
+        "        // receive result from a worker, which also\n",
+        "        // signals they would like some new work\n",
+        "        IntBuffer recvBuf = MPI.newIntBuffer(1);\n",
+        "        while (workCount < totalWork) {\n",
+        "            // System.out.println(\"Master workcount \" + workCount + \", total \"+ totalWork);\n",
+        "            // receive next finished result\n",
+        "            Status stat = comm.recv(recvBuf, 1, MPI.INT, MPI.ANY_SOURCE, WORKTAG);\n",
+        "            recvCount++;\n",
+        "            int workerId = stat.getSource();\n",
+        "            int completedWorkTime = recvBuf.get(0);\n",
+        "            System.out.println(\"master received \"+completedWorkTime+\" from \"+ workerId);\n",
+        "            // send next work\n",
+        "            int newWorkTime = workTimes[workCount++];\n",
+        "            sendBuf.put(0, newWorkTime);\n",
+        "            comm.send(sendBuf, 1, MPI.INT, workerId, WORKTAG);\n",
+        "            System.out.println(\"master sent \"+newWorkTime+\" to \"+ workerId);\n",
+        "        }\n",
+        "        // Receive results for outstanding work requests.\n",
+        "        while (recvCount < totalWork) {\n",
+        "            Status stat = comm.recv(recvBuf, 1, MPI.INT, MPI.ANY_SOURCE, WORKTAG);\n",
+        "            recvCount++;\n",
+        "            int workerId = stat.getSource();\n",
+        "            int completedWorkTime = recvBuf.get(0);\n",
+        "            System.out.println(\"end: master received \"+completedWorkTime+\" from \"+ workerId);\n",
+        "        }\n",
+        "\n",
+        "        // Tell all workers to stop\n",
+        "        sendBuf.put(0, -1);\n",
+        "        for(int id =1; id < numProcesses; id++) {\n",
+        "            comm.send(sendBuf, 1, MPI.INT, id, DIETAG);\n",
+        "        }\n",
+        "    }       \n",
+        "}\n"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "9t30ynerHaaN",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "43447a14-a733-47d7-e464-cc8baac75103"
+      },
+      "source": [
+        "!javac -cp ./mpi.jar DynamicLoadBalance.java \n",
+        "!mpirun --allow-run-as-root -np 4 java -cp ./mpi.jar DynamicLoadBalance"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "t65YHXekHbBK"
+      },
+      "source": [
+        "## Exercises\n",
+        "- Run, using N = 4 processes\n",
+        "- Study the execution carefully. Note that with 4 processes, 3 are workers. The total number of tasks is 3*4, or 12. Which process does the most work? You can count by looking for the lines that end with \"... from X\", where X is a worker process id.\n",
+        "- Try with N = 8 (7 workers)."
+      ]
+    }
+  ]
+}

--- a/Patternlets/java-OpenMPI/notebook/Java_openmpi_patternlets.ipynb
+++ b/Patternlets/java-OpenMPI/notebook/Java_openmpi_patternlets.ipynb
@@ -52,7 +52,10 @@
       },
       "source": [
         "# Distributed Parallel Programming Patterns using Open MPI and Java\n",
-        "Java adaptation done by Ruth Kurniawati (Westfield State University) using source code from [CSInParallel](https://github.com/csinparallel/CSinParallel.git)\n",
+        "\n",
+        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/rkurniawati/CSinParallel/blob/main/Patternlets/java-OpenMPI/notebook/Java_openmpi_patternlets.ipynb)\n",
+        "\n",
+        "Java adaptation done by Ruth Kurniawati (Westfield State University) using source code from [CSInParallel](https://github.com/csinparallel/CSinParallel.git). \n",
         "\n",
         "Modified from mpi4py notebook originally written by Libby Shoop, Macalester College\n",
         "\n",

--- a/Patternlets/java-OpenMPI/notebook/Java_openmpi_patternlets.ipynb
+++ b/Patternlets/java-OpenMPI/notebook/Java_openmpi_patternlets.ipynb
@@ -52,10 +52,7 @@
       },
       "source": [
         "# Distributed Parallel Programming Patterns using Open MPI and Java\n",
-        "\n",
-        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/rkurniawati/CSinParallel/blob/main/Patternlets/java-OpenMPI/notebook/Java_openmpi_patternlets.ipynb)\n",
-        "\n",
-        "Java adaptation done by Ruth Kurniawati (Westfield State University) using source code from [CSInParallel](https://github.com/csinparallel/CSinParallel.git). \n",
+        "Java adaptation done by Ruth Kurniawati (Westfield State University) using source code from [CSInParallel](https://github.com/csinparallel/CSinParallel.git)\n",
         "\n",
         "Modified from mpi4py notebook originally written by Libby Shoop, Macalester College\n",
         "\n",

--- a/Patternlets/java-OpenMPI/notebook/README.md
+++ b/Patternlets/java-OpenMPI/notebook/README.md
@@ -1,0 +1,5 @@
+# Java Open MPI Notebook
+
+You can open this notebook in Google Colab using the link below.
+
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/rkurniawati/CSinParallel/blob/main/Patternlets/java-OpenMPI/notebook/Java_openmpi_patternlets.ipynb)

--- a/Patternlets/java-OpenMPI/notebook/README.md
+++ b/Patternlets/java-OpenMPI/notebook/README.md
@@ -1,5 +1,5 @@
 # Java Open MPI Notebook
 
-You can open this notebook in Google Colab using the link below.
+You can open this notebook in Google Colab using the link below and start working on the examples. 
 
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/rkurniawati/CSinParallel/blob/main/Patternlets/java-OpenMPI/notebook/Java_openmpi_patternlets.ipynb)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/csinparallel/CSinParallel/blob/main/Patternlets/java-OpenMPI/notebook/Java_openmpi_patternlets.ipynb)


### PR DESCRIPTION
Changes in this pull request:
- added a notebook directory under Patternlets/java-OpenMPI to keep the Java version of the OpenMPI notebook (adapted from Libby Shoop's mpi4py notebook). The notebook can be launched in Google Colab using the link provided in README.md. 
- added the source code and build files for the dynamic load balancing example (adapted from the mpi4py's patternlet 17dynamicLoadBalance.py)

Thanks,
Ruth